### PR TITLE
Potential fix for code scanning alert no. 406: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  dependency-graph: write
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Marketingtool-pro/AiMarketingtool-pro-fbaf2fad/security/code-scanning/406](https://github.com/Marketingtool-pro/AiMarketingtool-pro-fbaf2fad/security/code-scanning/406)

Add an explicit `permissions` block to `.github/workflows/maven.yml` so the workflow no longer relies on potentially over-privileged defaults.

Best fix (without changing intended functionality):
- Add a workflow-level `permissions` block right after the `on:` trigger section (before `jobs:`).
- Set:
  - `contents: read` (required for checkout/read repository content)
  - `dependency-graph: write` (needed by the dependency submission action to upload dependency graph data)

This is the least-privilege explicit configuration for the currently defined steps while preserving behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions to allow dependency reporting.
  * Pinned CI action versions for more stable builds.
  * Enabled Maven caching to speed up builds.
  * Adjusted build to use the repository root project configuration.
  * Added dependency-graph submission step to report dependencies to the security dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->