### PR TITLE
Release build 482 / versionCode 491 — ship Master's fixed StoreKit 2 IAP

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "pro.marketingtool.app",
-      "buildNumber": "480",
+      "buildNumber": "482",
       "googleServicesFile": "./GoogleService-Info.plist",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
@@ -55,7 +55,7 @@
       },
       "googleServicesFile": "./google-services.json",
       "package": "pro.marketingtool.app",
-      "versionCode": 480,
+      "versionCode": 491,
       "allowBackup": false,
       "permissions": [
         "CAMERA",


### PR DESCRIPTION
## Why
The phone app was rejected 11× under **App Store Guideline 2.1(b)** — "error message upon trying to purchase a subscription." Deep investigation found the real cause:

- **The builds being submitted (478–481) were stale** — they shipped the old `billingService.ts` that **blocked the purchase on a server `iap-verify` call that does not exist**, so every purchase returned `Verification failed` / "not available."
- **`Master` already fixed this**: event-based v15 (`purchaseUpdatedListener`) + **best-effort, non-blocking** server verification (StoreKit 2 success = success). `Master` also has the Android 16 / 16 KB-page-size / `NitroIap` config.

This PR ships `Master`'s already-correct code as a fresh, submittable build.

## Changes
- iOS `buildNumber` **480 → 482** (481 was already uploaded to App Store Connect for 1.5.0 → "build number already used").
- Android `versionCode` **480 → 491** (above the previously attempted 490; keeps Play uploads monotonic).

No code logic changed — `Master`'s IAP fix is untouched.

## After merge — to ship
```
bun run ship        # eas build --platform all --profile production --auto-submit
```

## Still requires (outside code)
- **Android "users can't upgrade" error**: check Play Console for an in-progress staged rollout or a higher versionCode in a testing track — that error is rollout/targeting state, not the binary.
- Confirm the subscription products are **Cleared for Sale** + attached to the 1.5.0 version in App Store Connect (user reports this is already connected for 478).

🤖 Generated with [Claude Code](https://claude.com/claude-code)