### PR TITLE
fix: react 19.2.6 → 19.2.3 — stops launch crash (matches RN 0.85.3 renderer)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,8 +75,8 @@
         "genkit": "^1.36.0",
         "lottie-react-native": "~7.3.8",
         "material-symbols": "^0.44.10",
-        "react": "19.2.6",
-        "react-dom": "19.2.6",
+        "react": "19.2.3",
+        "react-dom": "19.2.3",
         "react-native": "0.85.3",
         "react-native-appwrite": "0.31.0",
         "react-native-edge-to-edge": "^1.8.1",
@@ -3933,9 +3933,9 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.57.tgz",
-      "integrity": "sha512-7dpOu9/qiodmFohZVpTxYmTcjbcXfstWeHof0Ka5RkhguKMkbS3c+sW23a7TTjtlViTV73z+IZFfFW1ru621kw==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.58.tgz",
+      "integrity": "sha512-B5s05UYjRD/MCUraK3MFc8WAKuVZTuCrhOsVxtaT0b/BjWHkrZiSXStfYTjuFAkT5y8a/NUCMOMZuAzViYl4aQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "detect-libc": "^2.1.2"
@@ -3944,20 +3944,20 @@
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.57",
-        "@github/copilot-darwin-x64": "1.0.57",
-        "@github/copilot-linux-arm64": "1.0.57",
-        "@github/copilot-linux-x64": "1.0.57",
-        "@github/copilot-linuxmusl-arm64": "1.0.57",
-        "@github/copilot-linuxmusl-x64": "1.0.57",
-        "@github/copilot-win32-arm64": "1.0.57",
-        "@github/copilot-win32-x64": "1.0.57"
+        "@github/copilot-darwin-arm64": "1.0.58",
+        "@github/copilot-darwin-x64": "1.0.58",
+        "@github/copilot-linux-arm64": "1.0.58",
+        "@github/copilot-linux-x64": "1.0.58",
+        "@github/copilot-linuxmusl-arm64": "1.0.58",
+        "@github/copilot-linuxmusl-x64": "1.0.58",
+        "@github/copilot-win32-arm64": "1.0.58",
+        "@github/copilot-win32-x64": "1.0.58"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.57.tgz",
-      "integrity": "sha512-ZmsojZbitPSRfgw3W9wBrHGLRDsBvMCjGsGnJ7xXOU6qxeF/IyWHADxEv1WKfDw8BdCM+LE5yITPXB8bcvCdqQ==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.58.tgz",
+      "integrity": "sha512-OdK1zIMca1rW9SjdDsjAQy2wJPYgXYfYY5Ia96RcUQH3nkrrQtaQ6zyQRWqueIg4rL0IZf8sqqYxNW+iKdSnyQ==",
       "cpu": [
         "arm64"
       ],
@@ -3971,9 +3971,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.57.tgz",
-      "integrity": "sha512-F4TFDOdORy4oSHJS4DE+3sTk09uk1lohOloe0jfvoEVxJSU6jdQcJLNGoo+BQljcG7a1HEBrmB04iAWG1UXVfA==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.58.tgz",
+      "integrity": "sha512-OexNIomHyqCblLSs9JPu68WbmMX31rPU0GxpLrs9CuKEnEueGcFqGOlFHBoXMg/c0R80bGD/GtSALR2mv64NMQ==",
       "cpu": [
         "x64"
       ],
@@ -3987,9 +3987,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.57.tgz",
-      "integrity": "sha512-6apNY/v7CMxKk45CctUZLzQnddBpIG9keSendFKYN+kBIEBSdy//s/Cz/4YQX1iERnklpgZRP7FvcwaKs0/7YA==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.58.tgz",
+      "integrity": "sha512-hP4ed+KQ45YrJfq8aLbTYGuYZJ2wzfycfj3ZDLd0rhSNcxog+OhAM3SWs/TNgrn/8xLK0xBWGk4yeasjJBSvKg==",
       "cpu": [
         "arm64"
       ],
@@ -4006,9 +4006,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.57.tgz",
-      "integrity": "sha512-EOOnU4Y+vZHfxVl8eBAP7JtSTmu5d4ZDUC9wCGpAA5k703lEnpu8UOv04mTHRn8KTzb8gj+ijNhxDWe3Xljbaw==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.58.tgz",
+      "integrity": "sha512-sc1gGwJbAYYZB+Tt/ZxbtZDMkIr8AvUmPsC9NAdVD0Sng5BB5Ujtku/5Xh7hj/psokEnzqFnZRa0V3wR/40Fng==",
       "cpu": [
         "x64"
       ],
@@ -4025,9 +4025,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.57.tgz",
-      "integrity": "sha512-FCAaaJLX5T2ZpMeS1TCNnhQuGqyH9WVZndFdN1VOEnN/iWeSSaVF3lM4TPyRHHnWDVxzZtB+VLqOSjINZntD6g==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.58.tgz",
+      "integrity": "sha512-A8jaXmS0Hymt7aYxhK7UKB3tFQSLBaljwZRKWKVxKRHeHOGAlm0xszvPsTAyVZJj0Lf0bIErxAwpU5C8P2QEpQ==",
       "cpu": [
         "arm64"
       ],
@@ -4044,9 +4044,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.57.tgz",
-      "integrity": "sha512-AMIBN830yOvNcrj2Q0tGMImqat/V24wZS/4m5BaUssELM7r7KrT9ZBnBs+nWDZYeQaRoblFWL3f4AfxE3t94lQ==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.58.tgz",
+      "integrity": "sha512-GrBHvnLNC1qO1rCQR7Vp/pduYFYk5XTC/pHFh2qA95ntR/Uis58J0y9O4jNYc+q0/3NK9RVdL+RxLGTyxApwpA==",
       "cpu": [
         "x64"
       ],
@@ -4063,12 +4063,12 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "1.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.0-beta.9.tgz",
-      "integrity": "sha512-D4yiGL4/faFCjL7bozhX7bgxt/x1wp2LZ2p9Tw+xrA5hbcLh5Be5kPen+bFA8NbVfgt1G2djDYFZlrZjXXmcBw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.0.tgz",
+      "integrity": "sha512-OKjmJMDM+GB2uHr8UA6O0FNs1Gfw/tkoE5vUNlYmKbydc9Yjf6pvuBdseGjAVvzc6f9HIbB5eZKLUrxbOTw+yA==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.55-5",
+        "@github/copilot": "^1.0.57",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -4077,9 +4077,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.57.tgz",
-      "integrity": "sha512-3TL2bd1/p/sYbNgDIqbnjES//zlXP5b0sPEXKQRrpVF9ZLN3vjQ1tmBWx8Qx7zn2J3oywH2dG7qKjuxWTJRXKA==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.58.tgz",
+      "integrity": "sha512-CT8d3ryh+nQHND2KWOaYMXwCCQbKD7pcTwHj2AJWTD0kVURqr0xWZdEI0YGOqr+dveK8y8j7+WRy+aWoXBxp4A==",
       "cpu": [
         "arm64"
       ],
@@ -4093,9 +4093,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.57.tgz",
-      "integrity": "sha512-zuKqRn0pIF+ZvuiMXbZkYK1AMlrV21kFTpyf5l7gdI1dzJuwHNI0Qfe0gzaZYaU1B4htbzMk9MhEbjR1PQcoJg==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.58.tgz",
+      "integrity": "sha512-eaXFT2/rZLbZbkhUFupk6uqSeWexVv3+PxA49TV6RR7BHMvG7wbyGhCbqwUDrmIRlLVSyDwriEStey7e2fvXkw==",
       "cpu": [
         "x64"
       ],
@@ -14673,14 +14673,14 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.39.1.tgz",
-      "integrity": "sha512-W+gVXA7BpRF1xLlS1kGTtKVaqd5yonqbGESKiPtIUXjV744GdDz8IG7RVsSY5KzHbgxuJBHKaJYk+92OIHTskQ==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.40.0.tgz",
+      "integrity": "sha512-jChWEB45q+9Ibryc7hg0l6hB1xA4zwE2y6ZhkhGP6oJkqYeiURkMagA2ZQZYMy1/T8PZ9ztoVJJtbL/+Ob851Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0",
-        "ws": "8.18.0"
+        "ws": "8.20.1"
       },
       "bin": {
         "convex": "bin/main.js"
@@ -15615,9 +15615,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.364",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.364.tgz",
-      "integrity": "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==",
+      "version": "1.5.366",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.366.tgz",
+      "integrity": "sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -19610,9 +19610,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/material-symbols": {
-      "version": "0.44.10",
-      "resolved": "https://registry.npmjs.org/material-symbols/-/material-symbols-0.44.10.tgz",
-      "integrity": "sha512-N/sAHC6C6s/cBG+o64tjosppMw2sC/rqo4AhANG4GTpH2E0X1VaIy5P77Rehk1NcPg22JRIbr9aKQkbX/a8REQ==",
+      "version": "0.44.11",
+      "resolved": "https://registry.npmjs.org/material-symbols/-/material-symbols-0.44.11.tgz",
+      "integrity": "sha512-xYOSzQkoM54dANcCWaAHVayHTDGnhS7JjpE+UuI+xGzE9OLZd8VLuYp2nbVCvSj8gPDTscUHGBqvZoBAYMzYvw==",
       "license": "Apache-2.0"
     },
     "node_modules/math-intrinsics": {
@@ -20385,9 +20385,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -21343,9 +21343,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -21362,15 +21362,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.3"
       }
     },
     "node_modules/react-freeze": {

--- a/package.json
+++ b/package.json
@@ -123,8 +123,8 @@
     "genkit": "^1.36.0",
     "lottie-react-native": "~7.3.8",
     "material-symbols": "^0.44.10",
-    "react": "19.2.6",
-    "react-dom": "19.2.6",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
     "react-native": "0.85.3",
     "react-native-appwrite": "0.31.0",
     "react-native-edge-to-edge": "^1.8.1",
@@ -169,7 +169,9 @@
     "@opentelemetry/auto-instrumentations-node": ">=0.75.0",
     "@opentelemetry/sdk-node": ">=0.217.0",
     "@opentelemetry/exporter-prometheus": ">=0.217.0",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "react": "19.2.3",
+    "react-dom": "19.2.3"
   },
   "resolutions": {
     "expo-file-system": "~55.0.10",
@@ -180,7 +182,9 @@
     "semver": "^7.7.4",
     "send": "^0.19.0",
     "tar": "^7.5.13",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "react": "19.2.3",
+    "react-dom": "19.2.3"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## 🚨 Critical — fixes a launch crash on BOTH platforms

The Android **pre-launch report** caught a fatal crash:
```
FATAL EXCEPTION: expo-updates-error-recovery
JavascriptException: [runtime not ready]: Incompatible React versions:
  - react:                 19.2.6
  - react-native-renderer: 19.2.3
```
React requires `react` and `react-native-renderer` to be the **exact same version**. RN **0.85.3 bundles renderer 19.2.3**, but `package.json` pinned **`react: 19.2.6` / `react-dom: 19.2.6`** (a dependabot bump). Result: the JS runtime refuses to start → **immediate crash on launch** (platform-agnostic — affects iOS *and* Android, i.e. the "479 wrong / 481 crash").

## Fix
- `react` / `react-dom` **19.2.6 → 19.2.3** (exact match to RN 0.85.3's renderer)
- Added `react`/`react-dom` to `overrides` + `resolutions` so no transitive dep re-introduces 19.2.6
- `package-lock.json` regenerated (npm, `--legacy-peer-deps`) — verified **0 occurrences of 19.2.6**, valid integrity hashes

## ⚠️ Important
Build **482** (from #99) was built with react 19.2.6 → it will crash. **Re-trigger the production build after merging this** so the binary picks up react 19.2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated React and React-DOM dependencies to version 19.2.3
  * Added version pinning configuration for dependency consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->