### PR TITLE
ci(android): submit as draft — stops the "cannot rollout" headless failure

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -43,7 +43,7 @@
       },
       "android": {
         "track": "production",
-        "releaseStatus": "completed"
+        "releaseStatus": "draft"
       }
     }
   }


### PR DESCRIPTION
Android auto-submit keeps failing with Google Play's *"You cannot rollout this release because it does not allow any existing users to upgrade to the newly added APKs"* — a **Play Console rollout/targeting state**, not a binary problem (same AAB config as a previously-working build; versionCode bumps didn't help).

`releaseStatus: completed` tells Google to roll out to 100% immediately, which triggers the failing upgrade-eligibility check. Switching to **`draft`** uploads the AAB without attempting rollout, so the submit succeeds; you then publish it manually in Play Console — where the exact device/track reason is shown and clickable.

iOS submission is unchanged (still fully automated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)