### PR TITLE
ci: deploy only on version tag / manual dispatch (stop per-push build churn) + Node 24

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -2,7 +2,6 @@ name: Production Deploy
 
 on:
   push:
-    branches: [main, Master]
     tags:
       - 'v*.*.*'
   workflow_dispatch:
@@ -28,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - uses: expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e  # v8
@@ -59,7 +58,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - uses: expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e  # v8
@@ -95,7 +94,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - uses: expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e  # v8
@@ -126,7 +125,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - uses: expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e  # v8


### PR DESCRIPTION
## Why
`production-deploy.yml` triggered on `push: branches: [main, Master]`, so **every merge to Master launched a full EAS build + store submission** — that's the source of the "~500 builds" churn (478 → 493+). A production store submission should be **intentional**, not per-commit.

## Change
- **Trigger:** remove `push: branches: [main, Master]` → keep **`push: tags: ['v*.*.*']`** + `workflow_dispatch`
- **Node:** `setup-node` 20 → 24 (Node 20 deprecated)

## Effect
Merges to Master no longer auto-build. A production build+submit runs **only** when you:
- push a **`v1.5.x` tag**, or
- run the org **`ai-marketingtool-llc → full-project.yml`** (`target=phone`, `phone_ref=Master`, `run_phone_deploy=true`)

The in-flight crash-free build (from #100/#101) is unaffected — it keeps running. This only stops *future* per-merge churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure for production deployment pipelines to support latest tooling and improve deployment automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->