### PR TITLE
fix(android): patch RN 0.85.3 edge-to-edge deprecated APIs (replaces stale 0.83.6 AAR)

### DIFF
--- a/patches/react-native+0.85.3.patch
+++ b/patches/react-native+0.85.3.patch
@@ -1,0 +1,30 @@
+diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
+index 0cff3bc..959078c 100644
+--- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
++++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
+@@ -113,13 +113,18 @@ internal fun Window.enableEdgeToEdge() {
+     isNavigationBarContrastEnforced = true
+   }
+ 
+-  statusBarColor = Color.TRANSPARENT
+-  navigationBarColor =
+-      when {
+-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> Color.TRANSPARENT
+-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !isDarkMode -> LightNavigationBarColor
+-        else -> DarkNavigationBarColor
+-      }
++  // Android 15 (API 35) edge-to-edge: Window.setStatusBarColor / setNavigationBarColor are
++  // deprecated and flagged by Google Play. On 35+ the transparent system bars are handled by
++  // WindowCompat.setDecorFitsSystemWindows(false) above, so skip the deprecated setters there.
++  if (Build.VERSION.SDK_INT < 35) {
++    statusBarColor = Color.TRANSPARENT
++    navigationBarColor =
++        when {
++          Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> Color.TRANSPARENT
++          Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !isDarkMode -> LightNavigationBarColor
++          else -> DarkNavigationBarColor
++        }
++  }
+ 
+   WindowInsetsControllerCompat(this, decorView).run {
+     isAppearanceLightNavigationBars = !isDarkMode


### PR DESCRIPTION
## The real AAR issue (verified)
- The maven AAR `react-android-0.83.6-e2e.1` targets RN **0.83.6**; the app is on **0.85.3**
- `withRNEdgeToEdgeFix` (which would consume it) is **not** in `app.json` plugins
- `patches/` only patches Firebase — **not** react-native

→ So RN's deprecated edge-to-edge APIs (`Window.setStatusBarColor` / `setNavigationBarColor` in `WindowUtil.enableEdgeToEdge()`) were **never actually patched.** The AAR issue was genuinely unfixed.

## Fix
A **patch-package patch for RN 0.85.3** (your existing `postinstall: npx patch-package` applies it) that wraps the deprecated setters in `if (Build.VERSION.SDK_INT < 35)` — the same guard the `android-patches` AAR intended, but version-matched. On API 35+ transparent bars come from `WindowCompat.setDecorFitsSystemWindows(false)`; the deprecated setters are skipped.

Pure additive guard around existing valid code → compiles as-is.

## ⚠️ Verify before relying on it
This is **native Kotlin** — it must compile in a real Android build. **Do not treat it as "fixed" until an EAS Android build succeeds with it.** Recommend merging only after one green Android build.

## Follow-up (separate)
With this in place, the AAR machinery is fully redundant and carries a **leaked PAT** — `android-patches/`, `withRNEdgeToEdgeFix.js`, and `patch-react-android.yml` should be removed (and that token revoked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)