### PR TITLE
Potential fix for code scanning alert no. 410: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,9 @@ on:
     branches: [Master, main, develop]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Marketingtool-pro/AiMarketingtool-pro-fbaf2fad/security/code-scanning/410](https://github.com/Marketingtool-pro/AiMarketingtool-pro-fbaf2fad/security/code-scanning/410)

Add an explicit top-level `permissions` block in `.github/workflows/build-and-test.yml` so all jobs inherit least-privilege token access.

Best single fix without changing functionality:
- Insert at workflow root (after `on:` block, before `jobs:`):
  - `permissions:`
  - `contents: read`

This is sufficient for `actions/checkout` and typical read-only workflow operations and addresses the CodeQL finding for all jobs in this workflow in one place.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
