### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/scripts/asc_submit_512.rb
+++ b/scripts/asc_submit_512.rb
@@ -38,7 +38,7 @@ puts "\nIn-progress review submissions to CLEAR (#{inflight.size}):"
 inflight.each{|s| puts "  - #{s['id']} state=#{s['attributes']['state']} items=#{(s.dig('relationships','items','data')||[]).size}"}
 
 # IAPs
-c,g=req(:get,"/v1/apps/#{APP}/subscriptionGroups?include=subscriptions&limit=50")
+_,g=req(:get,"/v1/apps/#{APP}/subscriptionGroups?include=subscriptions&limit=50")
 sbs=((g["included"]||[]).select{|i| i["type"]=="subscriptions"})
 c,i=req(:get,"/v1/apps/#{APP}/inAppPurchasesV2?limit=50")
 cons=(i["data"]||[])


### PR DESCRIPTION
The best fix is to stop assigning the unused HTTP status to `c` for the call on line 41, while preserving the payload (`g`) that is actually used. In Ruby, replace `c,g=req(...)` with `_,g=req(...)` to explicitly ignore the first return value.  
Make this change in `scripts/asc_submit_512.rb` at the IAPs section (around lines 41–42). No imports, new methods, or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API response handling to ensure data is properly processed from responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->