### PR TITLE
fix(phone): remove broken 'View Full on Desktop' 404 dead-end on tool results

### DIFF
--- a/src/screens/main/HistoryScreen.tsx
+++ b/src/screens/main/HistoryScreen.tsx
@@ -226,9 +226,14 @@ const HistoryScreen = () => {
           <TouchableOpacity
             style={styles.expandBtn}
             onPress={() => {
+              // Generations store the tool's $id in `toolId`; ToolResultScreen needs the slug.
+              const toolSlug = tools.find(t => t.$id === item.toolId)?.slug ?? item.toolId;
               navigation.navigate('ToolResult', {
-                result: item.output,
-                toolSlug: item.toolId,
+                // ToolResultScreen expects result.outputs: string[]; the saved output is a
+                // single string joined with this separator when generated.
+                result: { outputs: item.output.split('\n\n---\n\n') },
+                toolSlug,
+                inputs: item.input,
               } as any);
             }}
           >

--- a/src/screens/tools/ToolResultScreen.tsx
+++ b/src/screens/tools/ToolResultScreen.tsx
@@ -102,12 +102,6 @@ const ToolResultScreen = () => {
     return isDesktopCategory || isDesktopSlug || isLongContent;
   }, [tool, outputs]);
 
-  const desktopUrl = tool ? `https://app.marketingtool.pro/dashboard/tool/${tool.slug}` : '';
-
-  const handleViewOnDesktop = () => {
-    Linking.openURL(desktopUrl);
-  };
-
   const handleEmailResult = async () => {
     const allContent = outputs.map(o => o.content).join('\n\n---\n\n');
     const subject = encodeURIComponent(`${tool?.name || 'Tool'} Result - MarketingTool`);
@@ -281,28 +275,24 @@ const ToolResultScreen = () => {
               <Text style={styles.outputText}>{output.content}</Text>
             )}
 
-            {/* Desktop banner for large/complex tool outputs */}
+            {/* Long-result banner — full output is available on this screen */}
             {isLargeOutput && (
               <View style={styles.desktopBanner}>
                 <View style={styles.desktopBannerHeader}>
-                  <Feather name="monitor" size={18} color={Colors.secondary} />
-                  <Text style={styles.desktopBannerTitle}>Best viewed on desktop</Text>
+                  <Feather name="file-text" size={18} color={Colors.secondary} />
+                  <Text style={styles.desktopBannerTitle}>Long result</Text>
                 </View>
                 <Text style={styles.desktopBannerText}>
-                  The tool completed successfully. This result is long, so we show a preview on mobile for readability. You can view the full output on desktop anytime.
+                  This result is long, so we show a preview for readability. Tap “Show full result” above to expand it, or email/copy the full text below.
                 </Text>
                 <View style={styles.desktopActions}>
-                  <TouchableOpacity style={styles.desktopActionBtn} onPress={handleViewOnDesktop}>
-                    <Feather name="external-link" size={16} color={Colors.white} />
-                    <Text style={styles.desktopActionText}>View Full on Desktop</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity style={styles.desktopActionBtnOutline} onPress={handleEmailResult}>
-                    <Feather name="mail" size={16} color={Colors.secondary} />
-                    <Text style={styles.desktopActionOutlineText}>Email Full Result</Text>
+                  <TouchableOpacity style={styles.desktopActionBtn} onPress={handleEmailResult}>
+                    <Feather name="mail" size={16} color={Colors.white} />
+                    <Text style={styles.desktopActionText}>Email Full Result</Text>
                   </TouchableOpacity>
                   <TouchableOpacity style={styles.desktopActionBtnOutline} onPress={() => handleCopy(output.content, output.id)}>
                     <Feather name="copy" size={16} color={Colors.secondary} />
-                    <Text style={styles.desktopActionOutlineText}>Copy Summary</Text>
+                    <Text style={styles.desktopActionOutlineText}>Copy Full Result</Text>
                   </TouchableOpacity>
                 </View>
               </View>


### PR DESCRIPTION
## What you see (both screenshots are the phone app)
Tapping **View Full on Desktop** on a tool result opens `app.marketingtool.pro` in the phone's in-app browser → **404 'Unexpected Application Error'**. The link also carried no result data.

## Fix (phone-side, JS-only)
- **ToolResultScreen**: remove the `View Full on Desktop` button + `handleViewOnDesktop`/`desktopUrl`. The full output is already on-device — surface it via the existing **Show full result** toggle, plus **Email Full Result** / **Copy**. Banner reworded (no more desktop dead-end).
- **HistoryScreen**: fix 'View Full' — resolve the real tool slug from `toolId` and pass the `{ outputs: [...] }` shape `ToolResultScreen` expects (saved generations were rendering blank).

## Ship
JS/TSX only, no native change → rides **Expo auto-publish (OTA)** to both platforms on merge. No native build needed.

(The web app 404 itself is separate — fixed in web-app-router- PR #30, deploys on VPS 2.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected full result navigation from history screen with properly mapped result parameters and tool identifiers.

* **Improvements**
  * Simplified large output display experience by removing device-specific viewing options and consolidating available actions for consistent behavior across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->