### PR TITLE
fix(phone): chat shows REAL remaining credits (not fake 10)

### DIFF
--- a/src/screens/chat/ChatScreen.tsx
+++ b/src/screens/chat/ChatScreen.tsx
@@ -458,7 +458,7 @@ Be helpful, specific, and provide actionable advice. Use formatting with bullet 
           )}
           <View style={styles.creditsContainer}>
             <Feather name="zap" size={14} color={Colors.gold} />
-            <Text style={styles.creditsText}>{profile?.generationsCount || 10}</Text>
+            <Text style={styles.creditsText}>{Math.max(0, (profile?.generationsLimit ?? 0) - (profile?.generationsUsed ?? 0))}</Text>
           </View>
         </View>
       </View>


### PR DESCRIPTION
Chat credit badge showed `profile.generationsCount || 10` — but generations are consumed via `generationsUsed` (Appwrite-persisted), so `generationsCount` is a dead field that always rendered the hardcoded **10**. Now shows real remaining: `generationsLimit − generationsUsed`. JS-only → ships via OTA, no Apple review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the calculation of remaining generations displayed in the chat header to accurately reflect the difference between your generation limit and current usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->