### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/tools/ToolDetailScreen.tsx
+++ b/src/screens/tools/ToolDetailScreen.tsx
@@ -19,7 +19,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../navigation/AppNavigator';
 import { useToolsStore, Tool, ToolInput } from '../../store/toolsStore';
 import { useAuthStore } from '../../store/authStore';
-import { effectiveTier, hasProAccess, generationsLimitForTier } from '../../services/billingService';
+import { effectiveTier, generationsLimitForTier } from '../../services/billingService';
 import { imageService, GeneratedImage } from '../../services/imageService';
 import { Colors, Gradients, Spacing, BorderRadius, HEADER_TOP_PADDING } from '../../constants/theme';
 import { getToolIcon } from '../../constants/toolIcons';
@@ -37,7 +37,6 @@ const ToolDetailScreen = () => {
   // Tier-aware gating: Starter unlocks the standard platform, PRO-badged tools
   // need Pro or higher (matches marketingtool.pro/pricing).
   const tier = effectiveTier(profile?.subscription, localSubscriptionOverride);
-  const canUsePro = hasProAccess(profile?.subscription, localSubscriptionOverride);
 
   const [tool, setTool] = useState<Tool | null>(null);
   const [inputValues, setInputValues] = useState<Record<string, string>>({});


### PR DESCRIPTION
To fix an unused-variable issue without changing functionality, remove the variable declaration that is never used.

Best fix here:
- In `src/screens/tools/ToolDetailScreen.tsx`, remove the `canUsePro` declaration on line 40.
- Keep `tier` and all other logic untouched.
- No new imports, methods, or dependencies are needed.

This resolves the CodeQL warning and avoids introducing behavior changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tool access and generation limits to follow the user’s billing tier and available generation quota.
  * Removed the pre-generation “locked” state for tools, so access is now determined at generation time.
  * Improved the credits remaining display and upgrade prompt to match the same quota-based rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->