### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/main/DashboardScreen.tsx
+++ b/src/screens/main/DashboardScreen.tsx
@@ -179,7 +179,7 @@ const DashboardScreen = () => {
     localSubscriptionOverride === 'free';
   // PRO-badged tools need the Pro tier or higher, not just any paid plan.
   const canUsePro = hasProAccess(profile?.subscription, localSubscriptionOverride);
-  const { tools, fetchTools, isLoading, generations, fetchGenerations } = useToolsStore();
+  const { tools, fetchTools, generations, fetchGenerations } = useToolsStore();
   const [refreshing, setRefreshing] = React.useState(false);
 
   // Update counts when generations change


### PR DESCRIPTION
To fix this class of issue, remove variables/imports that are declared but never referenced, unless they are intentionally reserved for near-term use (in which case add a clear comment and naming convention).  
Here, the best non-functional-change fix is to edit `src/screens/main/DashboardScreen.tsx` at the `useToolsStore()` destructuring line and remove `isLoading` from the destructured fields.

This preserves runtime behavior (since unused bindings have no effect) and resolves the static analysis warning cleanly without adding unnecessary code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._