### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/scripts/asc_submit_512.rb
+++ b/scripts/asc_submit_512.rb
@@ -32,7 +32,7 @@ ver=(v["data"]||[]).find{|x| %w[PREPARE_FOR_SUBMISSION READY_FOR_REVIEW REJECTED
 puts "Version: #{ver['attributes']['versionString']} state=#{ver['attributes']['appStoreState']} (#{ver['id']})"
 
 # existing review submissions (the 409 source)
-c,subs=req(:get,"/v1/reviewSubmissions?filter[app]=#{APP}&include=items")
+_,subs=req(:get,"/v1/reviewSubmissions?filter[app]=#{APP}&include=items")
 inflight=(subs["data"]||[]).reject{|s| s["attributes"]["state"]=="COMPLETE"}
 puts "\nIn-progress review submissions to CLEAR (#{inflight.size}):"
 inflight.each{|s| puts "  - #{s['id']} state=#{s['attributes']['state']} items=#{(s.dig('relationships','items','data')||[]).size}"}


### PR DESCRIPTION
The fix is to stop binding the unused HTTP status code to `c` at line 35 and bind it to `_` instead, indicating intentional discard.

Best single change without altering functionality:
- In `scripts/asc_submit_512.rb`, update the parallel assignment under the “existing review submissions” section:
  - From: `c,subs=req(:get,"/v1/reviewSubmissions?filter[app]=#{APP}&include=items")`
  - To: `_,subs=req(:get,"/v1/reviewSubmissions?filter[app]=#{APP}&include=items")`

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._