### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/scripts/asc_autosubmit.rb
+++ b/scripts/asc_autosubmit.rb
@@ -138,7 +138,7 @@ puts "✔ build #{build['attributes']['version']} attached to version"
 #     iOS localization. Override text via env WHATS_NEW.
 whats_new = ENV['WHATS_NEW'] ||
   "Performance improvements and fixes. All tools now open on every plan, and full results are viewable on-device."
-code, locs = get("/v1/appStoreVersions/#{ver['id']}/appStoreVersionLocalizations?limit=50")
+_, locs = get("/v1/appStoreVersions/#{ver['id']}/appStoreVersionLocalizations?limit=50")
 (locs['data'] || []).each do |loc|
   lc = loc['attributes']['locale']
   c2, _ = req(:patch, "/v1/appStoreVersionLocalizations/#{loc['id']}",


### PR DESCRIPTION
Use Ruby’s conventional placeholder `_` for an intentionally ignored value in multiple assignment.

Best fix in this file: in `scripts/asc_autosubmit.rb`, at the localization fetch line (currently line 141), replace `code, locs = ...` with `_, locs = ...`. This preserves behavior exactly, removes the useless local assignment, and aligns with existing style already used in the script (`code, _ = ...`, `c2, _ = ...`, etc.). No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._