### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/scripts/asc_submit_512.rb
+++ b/scripts/asc_submit_512.rb
@@ -27,7 +27,7 @@ abort "build #{WANT_BUILD} not VALID/found" unless build
 puts "Build: #{WANT_BUILD} (#{build['id']})"
 
 # version
-c,v=req(:get,"/v1/apps/#{APP}/appStoreVersions?filter[platform]=IOS&limit=5")
+_,v=req(:get,"/v1/apps/#{APP}/appStoreVersions?filter[platform]=IOS&limit=5")
 ver=(v["data"]||[]).find{|x| %w[PREPARE_FOR_SUBMISSION READY_FOR_REVIEW REJECTED DEVELOPER_REJECTED METADATA_REJECTED].include?(x["attributes"]["appStoreState"])} || v["data"][0]
 puts "Version: #{ver['attributes']['versionString']} state=#{ver['attributes']['appStoreState']} (#{ver['id']})"
 


### PR DESCRIPTION
The best fix is to replace the unused local variable `c` with `_` for the call on line 30, matching the script’s existing style for intentionally ignored return values (as already done on line 41).

Concretely, in `scripts/asc_submit_512.rb`, update the tuple assignment under `# version` from:

- `c,v=req(:get,...)`

to:

- `_,v=req(:get,...)`

No functional behavior changes: the same API call occurs, `v` is still used exactly the same way, and the first returned value is explicitly ignored. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._