### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/scripts/asc_clear_sub_rejections.rb
+++ b/scripts/asc_clear_sub_rejections.rb
@@ -35,7 +35,7 @@ def req(m,p,b=nil)
 end
 puts "=== MODE: #{DRY ? 'DRY RUN (no changes)' : 'LIVE'} ==="
 SUBS.each do |sid|
-  c,loc=req(:get,"/v1/subscriptions/#{sid}/subscriptionLocalizations")
+  _,loc=req(:get,"/v1/subscriptions/#{sid}/subscriptionLocalizations")
   (loc["data"]||[]).each do |l|
     lid=l["id"]; a=l["attributes"]||{}; locale=a["locale"]; desc=a["description"].to_s; name=a["name"]
     newdesc = desc.end_with?(".") ? desc[0..-2] : desc + "."


### PR DESCRIPTION
In general, fix this by removing unused local assignments and only capturing values that are actually needed.

Best fix here: in `scripts/asc_clear_sub_rejections.rb`, change the destructuring assignment on line 38 from `c,loc=...` to `_,loc=...` so the first return value is explicitly ignored. This preserves behavior and makes intent clear without changing control flow or API calls. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._