### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/main/DashboardScreen.tsx
+++ b/src/screens/main/DashboardScreen.tsx
@@ -8,8 +8,6 @@ import {
   Dimensions,
   RefreshControl,
   Image,
-  Animated,
-  Easing,
   Platform,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';


### PR DESCRIPTION
Remove `Animated` and `Easing` from the `react-native` named import in `src/screens/main/DashboardScreen.tsx`.

Best fix without changing functionality:
- Edit the import block at the top of `DashboardScreen.tsx`.
- In the `from 'react-native'` import list (lines 2–14 in the snippet), delete only:
  - `Animated,`
  - `Easing,`
- Keep all other imports unchanged.
- No new methods, definitions, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._