### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/main/DashboardScreen.tsx
+++ b/src/screens/main/DashboardScreen.tsx
@@ -36,8 +36,6 @@ import NativeAdCard from '../../components/NativeAdCard';
 
 const { width } = Dimensions.get('window');
 
-const isVisionOS = (Platform.OS as any) === 'visionos';
-
 const Animations = {
   aiRobot: require('../../../assets/animations/ai-robot.js'),
   pulseGlow: require('../../../assets/animations/pulse-glow.js'),


### PR DESCRIPTION
To fix this without changing functionality, remove the unused `isVisionOS` constant declaration from `src/screens/main/DashboardScreen.tsx`. This addresses the CodeQL warning directly and does not alter runtime behavior, because unused code has no effect.

Best single change:
- In `src/screens/main/DashboardScreen.tsx`, delete line 39:
  - `const isVisionOS = (Platform.OS as any) === 'visionos';`

No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._