### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/chat/ChatScreen.tsx
+++ b/src/screens/chat/ChatScreen.tsx
@@ -24,7 +24,7 @@ import { useAuthStore, parseAppwriteResponse } from '../../store/authStore';
 import { functions, account } from '../../services/appwrite';
 import { ExecutionMethod } from 'react-native-appwrite';
 import { getToolIcon } from '../../constants/toolIcons';
-import { useToolsStore, Tool } from '../../store/toolsStore';
+import { useToolsStore } from '../../store/toolsStore';
 import { generationsLimitForTier } from '../../services/billingService';
 
 const { width } = Dimensions.get('window');


### PR DESCRIPTION
To fix this without changing functionality, remove the unused named import `Tool` from `src/screens/chat/ChatScreen.tsx` line 27, keeping `useToolsStore` intact.

Best single fix:
- Edit only the import line:
  - From: `import { useToolsStore, Tool } from '../../store/toolsStore';`
  - To: `import { useToolsStore } from '../../store/toolsStore';`

No additional methods, definitions, or package changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._