### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/main/DashboardScreen.tsx
+++ b/src/screens/main/DashboardScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import {
   View,
   Text,


### PR DESCRIPTION
To fix this, remove `useRef` from the React named imports in `src/screens/main/DashboardScreen.tsx` while keeping the rest of the import unchanged. This is the minimal, behavior-preserving fix for an unused import warning.

Best single change:
- Edit line 1 import statement in `src/screens/main/DashboardScreen.tsx`.
- Change:
  - `import React, { useEffect, useMemo, useRef } from 'react';`
- To:
  - `import React, { useEffect, useMemo } from 'react';`

No additional methods, definitions, or external imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._