### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/main/DashboardScreen.tsx
+++ b/src/screens/main/DashboardScreen.tsx
@@ -25,9 +25,8 @@ import { Feather } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../navigation/AppNavigator';
-import { hasProAccess, generationsLimitForTier } from '../../services/billingService';
-import { useAuthStore } from '../../store/authStore';
 import { generationsLimitForTier } from '../../services/billingService';
+import { useAuthStore } from '../../store/authStore';
 import { Colors, Spacing, BorderRadius, HEADER_TOP_PADDING } from '../../constants/theme';
 import { getToolIcon } from '../../constants/toolIcons';
 import LottieView from 'lottie-react-native';
@@ -173,8 +172,6 @@ const DashboardScreen = () => {
   const isFreeUser =
     (!profile?.subscription || profile.subscription === 'free') &&
     localSubscriptionOverride === 'free';
-  // PRO-badged tools need the Pro tier or higher, not just any paid plan.
-  const canUsePro = hasProAccess(profile?.subscription, localSubscriptionOverride);
 
   // Update counts when generations change
   const userGenerations = (user?.$id && generations.length > 0) ? generations.filter(g => g.userId === user.$id) : [];


### PR DESCRIPTION
The best fix is to remove the unused `canUsePro` declaration in `DashboardScreen`, since it is currently computed but not used. This preserves runtime behavior (no code depends on it) while resolving the lint/CodeQL issue cleanly.

In `src/screens/main/DashboardScreen.tsx`, delete:
- the comment directly introducing `canUsePro` (optional but recommended for clarity), and
- `const canUsePro = hasProAccess(profile?.subscription, localSubscriptionOverride);`

Because this removal also makes the `hasProAccess` import unused, update the billing service import to remove `hasProAccess` and keep only the actually used symbol(s). In the shown imports, `generationsLimitForTier` is imported twice; consolidate to a single import line with only used entries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._