### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/chat/ChatScreen.tsx
+++ b/src/screens/chat/ChatScreen.tsx
@@ -19,7 +19,7 @@ import { Feather } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../navigation/AppNavigator';
-import { Colors, Gradients, Spacing, BorderRadius, HEADER_TOP_PADDING } from '../../constants/theme';
+import { Colors, Spacing, BorderRadius, HEADER_TOP_PADDING } from '../../constants/theme';
 import { useAuthStore, parseAppwriteResponse } from '../../store/authStore';
 import { functions, account } from '../../services/appwrite';
 import { ExecutionMethod } from 'react-native-appwrite';


### PR DESCRIPTION
To fix an unused import warning without changing functionality, remove only the unused symbol from the named import list while leaving the rest intact.

In `src/screens/chat/ChatScreen.tsx`, update the import on line 22:

- From: `import { Colors, Gradients, Spacing, BorderRadius, HEADER_TOP_PADDING } ...`
- To: `import { Colors, Spacing, BorderRadius, HEADER_TOP_PADDING } ...`

No new methods, definitions, or dependencies are needed. This is the minimal and safest change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._