### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/marketingtool/dev/app/my-route/route.ts
+++ b/marketingtool/dev/app/my-route/route.ts
@@ -1,11 +1,6 @@
 import configPromise from '@payload-config'
-import { getPayload } from 'payload'
 
 export const GET = async (request: Request) => {
-  const payload = await getPayload({
-    config: configPromise,
-  })
-
   return Response.json({
     message: 'This is an example of a custom route.',
   })


### PR DESCRIPTION
General fix approach: remove unused variables (and any now-unneeded related code/imports) when they are not required for behavior. If the call has intended side effects, keep the call but avoid binding to a variable.

Best fix here without changing existing functionality:  
In `marketingtool/dev/app/my-route/route.ts`, remove the `getPayload` import and remove the `payload` initialization block in `GET`. The handler currently returns a static JSON payload and does not use the Payload instance, so deleting the unused setup avoids unnecessary work and resolves the warning cleanly.

Changes needed:
- Delete `import { getPayload } from 'payload'`.
- Delete lines creating `payload` (the `await getPayload({ config: configPromise })` block).
- Keep existing `configPromise` import and response unchanged (to avoid assumptions beyond shown code).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._