### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -283,12 +283,6 @@ export const billingService = {
    * Returns { pending: true } when the store sheet launched.
    */
   async requestPurchase(sku: string, userId: string): Promise<{ success: boolean; pending?: boolean; error?: string }> {
-    const getProductId = (product: unknown): string | undefined => {
-      if (!product || typeof product !== 'object') return undefined;
-      const p = product as { id?: string; productId?: string };
-      return p.id || p.productId;
-    };
-
     if (!iapAvailable()) {
       return { success: false, error: IAP_UNAVAILABLE_ERROR };
     }


### PR DESCRIPTION
The cleanest fix is to remove the unused local `getProductId` declaration from `requestPurchase` in `src/services/billingService.ts`.

- **General approach:** eliminate dead local declarations that are never referenced.
- **Best specific fix here:** delete lines 286–290 (the `const getProductId = ...` block) and leave all runtime behavior unchanged.
- **Location:** `src/services/billingService.ts`, inside `async requestPurchase(...)`, immediately after the function signature and before the `iapAvailable()` check.
- **No imports or new methods** are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._