### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/chat/ChatScreen.tsx
+++ b/src/screens/chat/ChatScreen.tsx
@@ -267,7 +267,7 @@ const ChatScreen = () => {
   };
 
   // Track consecutive errors for smart recovery
-  const [consecutiveErrors, setConsecutiveErrors] = useState(0);
+  const [, setConsecutiveErrors] = useState(0);
   const lastFailedMessage = useRef<string | null>(null);
 
   const handleSend = async (text?: string) => {


### PR DESCRIPTION
To fix this without changing functionality, replace the unused `consecutiveErrors` state with a setter-only destructuring pattern. In React, if only the setter is needed, you can skip the value slot: `const [, setConsecutiveErrors] = useState(0);`.

This change should be made in `src/screens/chat/ChatScreen.tsx` at the state declaration near line 270. No logic changes are required elsewhere because `setConsecutiveErrors(0)` is already used and remains valid. No imports or new methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._