### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/main/DashboardScreen.tsx
+++ b/src/screens/main/DashboardScreen.tsx
@@ -8,7 +8,6 @@ import {
   Dimensions,
   RefreshControl,
   Image,
-  Platform,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';


### PR DESCRIPTION
To fix this issue, remove the unused `Platform` symbol from the `react-native` destructured import in `src/screens/main/DashboardScreen.tsx`.

Best single fix without changing functionality:
- Edit only the import block at the top of `src/screens/main/DashboardScreen.tsx`.
- In the `react-native` import (lines 2–12 in the snippet), delete `Platform,`.
- No new imports, methods, or definitions are needed.

This resolves the static analysis warning while keeping runtime behavior unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._