### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/tools/ToolsScreen.tsx
+++ b/src/screens/tools/ToolsScreen.tsx
@@ -15,7 +15,6 @@ import { Feather } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { useToolsStore, Tool, TOOL_CATEGORIES, PLATFORMS } from '../../store/toolsStore';
 import { useAuthStore } from '../../store/authStore';
-import { hasProAccess } from '../../services/billingService';
 import { Colors } from '../../constants/theme';
 import { getToolIcon } from '../../constants/toolIcons';
 import * as Haptics from 'expo-haptics';
@@ -29,7 +28,6 @@ const ToolsScreen = () => {
   const { profile, localSubscriptionOverride } = useAuthStore();
   const isFreeUser = (!profile?.subscription || profile.subscription === 'free') && localSubscriptionOverride === 'free';
   // PRO-badged tools need the Pro tier or higher, not just any paid plan.
-  const canUsePro = hasProAccess(profile?.subscription, localSubscriptionOverride);
   const [searchQuery, setSearchQuery] = useState('');
   const [activePlatform, setActivePlatform] = useState('All');
   const [activeSubcategory, setActiveSubcategory] = useState('All');


### PR DESCRIPTION
To fix an unused-variable warning without changing functionality, remove the variable declaration that is never read. Here, `hasProAccess` is only used to initialize `canUsePro`, so both the `canUsePro` line and the now-unused `hasProAccess` import should be removed.

In `src/screens/tools/ToolsScreen.tsx`:
- Delete the import of `hasProAccess` from `../../services/billingService` (line 18 in snippet).
- Delete the `const canUsePro = ...` declaration (line 32 in snippet).
- Keep all other logic unchanged.

This resolves the CodeQL warning and avoids introducing dead imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._