### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/marketingtool/dev/app/my-route/route.ts
+++ b/marketingtool/dev/app/my-route/route.ts
@@ -1,5 +1,3 @@
-import configPromise from '@payload-config'
-
 export const GET = async (request: Request) => {
   return Response.json({
     message: 'This is an example of a custom route.',


### PR DESCRIPTION
The best fix is to remove the unused `configPromise` import from `marketingtool/dev/app/my-route/route.ts` while leaving the route behavior unchanged.

- **General approach:** delete imports that are not referenced.
- **Specific change:** remove line 1 (`import configPromise from '@payload-config'`).
- **Why this is best:** it resolves the CodeQL warning with no functional change, keeps the file clean, and avoids introducing unnecessary logic just to “use” the import.
- **What is needed:** no new methods, no new definitions, and no additional imports/dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._