### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/profile/SettingsScreen.tsx
+++ b/src/screens/profile/SettingsScreen.tsx
@@ -19,7 +19,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useAuthStore, parseAppwriteResponse } from '../../store/authStore';
 import { authService, functions } from '../../services/appwrite';
 import { ExecutionMethod } from 'react-native-appwrite';
-import { Colors, Gradients, Spacing, BorderRadius, HEADER_TOP_PADDING } from '../../constants/theme';
+import { Colors, Spacing, BorderRadius, HEADER_TOP_PADDING } from '../../constants/theme';
 import { biometricService } from '../../services/biometric';
 
 const SettingsScreen = () => {


### PR DESCRIPTION
The fix is to remove `Gradients` from the named import list in `src/screens/profile/SettingsScreen.tsx` so that only actually used theme exports remain. This preserves runtime behavior while eliminating the unused symbol warning.

Best single change:
- In `src/screens/profile/SettingsScreen.tsx`, edit the import on line 22:
  - From: `import { Colors, Gradients, Spacing, BorderRadius, HEADER_TOP_PADDING } from '../../constants/theme';`
  - To: `import { Colors, Spacing, BorderRadius, HEADER_TOP_PADDING } from '../../constants/theme';`

No new methods, definitions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._