### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/appwrite-functions/iap-verify/src/main.js
+++ b/appwrite-functions/iap-verify/src/main.js
@@ -74,7 +74,7 @@ module.exports = async ({ req, res, log, error }) => {
     body = {};
   }
 
-const { userId, productId, platform, appleReceipt, googlePurchaseToken } = body || {};
+const { userId, productId, platform, appleReceipt } = body || {};
 
   if (!userId || !productId || !platform) {
     return res.json({ success: false, error: "Missing required fields: userId, productId, platform" }, 400, CORS_HEADERS);


### PR DESCRIPTION
To fix this without changing functionality, remove `googlePurchaseToken` from the destructuring assignment on line 77 in `appwrite-functions/iap-verify/src/main.js`.

Best single fix:
- Edit the body destructuring line to only include currently used fields:
  - from: `{ userId, productId, platform, appleReceipt, googlePurchaseToken }`
  - to: `{ userId, productId, platform, appleReceipt }`
- No imports, methods, or additional definitions are needed.

This is the least invasive change and directly resolves the unused-variable issue.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._