### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/marketingtool/dev/next.config.mjs
+++ b/marketingtool/dev/next.config.mjs
@@ -1,8 +1,4 @@
 import { withPayload } from '@payloadcms/next/withPayload'
-import { fileURLToPath } from 'url'
-import path from 'path'
-
-const dirname = path.dirname(fileURLToPath(import.meta.url))
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {


### PR DESCRIPTION
The best fix is to remove the unused variable and any imports that only exist to support it, while keeping behavior unchanged.

In `marketingtool/dev/next.config.mjs`:
- Remove `fileURLToPath` import from `url` (line 2), because it is only used for `dirname`.
- Remove `path` import (line 3), same reason.
- Remove the `dirname` declaration (line 5).

No functional behavior changes are introduced because `dirname` is not used by `nextConfig` or the export.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._