### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/auth/SplashScreen.tsx
+++ b/src/screens/auth/SplashScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, StyleSheet, Animated, Dimensions, Image } from 'react-native';
+import { View, StyleSheet, Animated, Image } from 'react-native';
 import { Colors } from '../../constants/theme';
 
 


### PR DESCRIPTION
To fix an unused import, remove only the unused symbol from the import statement while leaving all used imports intact. This avoids changing runtime behavior and keeps the file clean.

In `src/screens/auth/SplashScreen.tsx`, edit the React Native import line (line 2 in the snippet) to remove `Dimensions` from the destructured imports. No other code changes, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._