### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/profile/NotificationsScreen.tsx
+++ b/src/screens/profile/NotificationsScreen.tsx
@@ -66,6 +66,10 @@ const NotificationsScreen = () => {
     })));
   };
 
+  useEffect(() => {
+    loadNotifications();
+  }, []);
+
   const markAsRead = (id: string) => {
     setNotifications(prev =>
       prev.map(n => (n.id === id ? { ...n, read: true } : n))


### PR DESCRIPTION
In general, fix unused-function findings by either removing dead code or actually using the function where intended. Here, because `loadNotifications` performs core screen behavior (fetching/staging notification history into state), the best fix is to call it when the screen mounts.

Best single fix without changing intended functionality:
- In `src/screens/profile/NotificationsScreen.tsx`, add a `useEffect` that invokes `loadNotifications()` once on mount.
- Keep existing logic intact; just wire it into lifecycle.
- No new imports are needed because `useEffect` is already imported on line 1.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._