### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/profile/SubscriptionScreen.tsx
+++ b/src/screens/profile/SubscriptionScreen.tsx
@@ -37,7 +37,7 @@ interface Plan {
 
 const SubscriptionScreen = () => {
   const navigation = useNavigation();
-  const { profile, refreshProfile, applyLocalEntitlement, grantCredits, grantEntitlement } = useAuthStore();
+  const { profile, applyLocalEntitlement, grantCredits, grantEntitlement } = useAuthStore();
   const [billingPeriod, setBillingPeriod] = useState<'monthly' | 'yearly'>('yearly');
   const [selectedPlan, setSelectedPlan] = useState<string>('pro');
   const [isLoading, setIsLoading] = useState(false);


### PR DESCRIPTION
To fix this cleanly without changing behavior, remove the unused `refreshProfile` binding from the `useAuthStore()` destructuring in `src/screens/profile/SubscriptionScreen.tsx` (line 40 region).

This preserves all runtime functionality because unused variables have no effect on behavior. No new imports, methods, or dependencies are needed. The only change is narrowing the destructured properties to those actually used: `profile`, `applyLocalEntitlement`, `grantCredits`, and `grantEntitlement`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._