### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/screens/tools/ToolsScreen.tsx
+++ b/src/screens/tools/ToolsScreen.tsx
@@ -25,9 +25,7 @@ const CARD_WIDTH = (width - 48 - 16) / 3;
 const ToolsScreen = () => {
   const navigation = useNavigation<any>();
   const { tools } = useToolsStore();
-  const { profile, localSubscriptionOverride } = useAuthStore();
-  const isFreeUser = (!profile?.subscription || profile.subscription === 'free') && localSubscriptionOverride === 'free';
-  // PRO-badged tools need the Pro tier or higher, not just any paid plan.
+  useAuthStore();
   const [searchQuery, setSearchQuery] = useState('');
   const [activePlatform, setActivePlatform] = useState('All');
   const [activeSubcategory, setActiveSubcategory] = useState('All');


### PR DESCRIPTION
The cleanest fix is to remove unused state derived solely for `isFreeUser` if it is not referenced anywhere in this file. In the shown snippet, `profile` and `localSubscriptionOverride` are only used to compute `isFreeUser`, so the best non-functional-change fix is:

1. Remove `isFreeUser` declaration.
2. Replace `const { profile, localSubscriptionOverride } = useAuthStore();` with a bare `useAuthStore();` call to preserve any store subscription side effects without introducing another unused-variable warning.

Apply this in `src/screens/tools/ToolsScreen.tsx` around lines 28–31.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._