### PR TITLE
Fix for Potentially uninitialized local variable

### DIFF
--- a/scripts/asc_autosubmit.rb
+++ b/scripts/asc_autosubmit.rb
@@ -34,6 +34,8 @@ TOKEN = JWT.encode({ iss: ISSUER_ID, iat: now, exp: now + 1100, aud: 'appstoreco
 BASE = 'https://api.appstoreconnect.apple.com'
 
 def req(method, path, body = nil)
+  res = nil
+  parsed = {}
   uri = URI("#{BASE}#{path}")
   klass = { get: Net::HTTP::Get, post: Net::HTTP::Post, patch: Net::HTTP::Patch }[method]
   raise ArgumentError, "Unsupported HTTP method: #{method.inspect}. Supported: :get, :post, :patch" unless klass
@@ -44,10 +46,12 @@ def req(method, path, body = nil)
   res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(r) }
   parsed = JSON.parse(res.body)
 rescue JSON::ParserError => e
-  warn "⚠️ Failed to parse JSON response for #{method.to_s.upcase} #{path} (status=#{res.code}): #{e.message}; body=#{res.body.to_s[0, 500].inspect}"
+  status = res&.code || 'no-response'
+  body_preview = res&.body.to_s[0, 500].inspect
+  warn "⚠️ Failed to parse JSON response for #{method.to_s.upcase} #{path} (status=#{status}): #{e.message}; body=#{body_preview}"
   parsed = {}
 ensure
-  return [res.code.to_i, parsed]
+  return [(res&.code || 0).to_i, parsed]
 end
 def get(p) = req(:get, p)
 


### PR DESCRIPTION
Initialize `res` (and `parsed`) before the risky operations, and make `rescue`/`ensure` nil-safe.  
Best fix without changing intended functionality:

- In `scripts/asc_autosubmit.rb`, inside `def req`, set:
  - `res = nil`
  - `parsed = {}`
  at the top of the method.
- In the `rescue JSON::ParserError` warning, use safe fallbacks for status/body when `res` is nil.
- In `ensure`, return a safe status code when `res` is nil (for example `0`) and always return `parsed` hash.

This preserves existing behavior (tuple return `[code, parsed]`) while eliminating uninitialized/nil dereference paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._