### PR TITLE
Fix for Assignment to constant

### DIFF
--- a/src/screens/main/DashboardScreen.tsx
+++ b/src/screens/main/DashboardScreen.tsx
@@ -165,7 +165,6 @@ const AnimatedStatCard = ({ stat, index, onPress }: { stat: any; index: number; 
 
 const DashboardScreen = () => {
   const navigation = useNavigation<NavigationProp>();
-  const { user, profile, localSubscriptionOverride } = useAuthStore();
   // A user is free only if BOTH the server profile and the local purchase
   const { user, profile, localSubscriptionOverride, generations } = useAuthStore();
   // and must win even when the server write failed (e.g. Apple's sandbox).


### PR DESCRIPTION
Remove the duplicate `useAuthStore()` destructuring and keep a single declaration that includes all needed fields (`user`, `profile`, `localSubscriptionOverride`, `generations`).

Best fix (no functionality change):
- In `src/screens/main/DashboardScreen.tsx`, within `DashboardScreen`, delete:
  - `const { user, profile, localSubscriptionOverride } = useAuthStore();`
- Keep:
  - `const { user, profile, localSubscriptionOverride, generations } = useAuthStore();`

This preserves behavior while eliminating invalid duplicate `const` declarations that trigger the CodeQL finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._