### PR TITLE
fix(asc): restore working req() in asc_autosubmit.rb (revert autofix mangle)

### DIFF
--- a/scripts/asc_autosubmit.rb
+++ b/scripts/asc_autosubmit.rb
@@ -34,6 +34,8 @@ TOKEN = JWT.encode({ iss: ISSUER_ID, iat: now, exp: now + 1100, aud: 'appstoreco
 BASE = 'https://api.appstoreconnect.apple.com'
 
 def req(method, path, body = nil)
+  res = nil
+  parsed = {}
   uri = URI("#{BASE}#{path}")
   klass = { get: Net::HTTP::Get, post: Net::HTTP::Post, patch: Net::HTTP::Patch }[method]
   raise ArgumentError, "Unsupported HTTP method: #{method.inspect}. Supported: :get, :post, :patch" unless klass
@@ -44,10 +46,12 @@ def req(method, path, body = nil)
   res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(r) }
   parsed = JSON.parse(res.body)
 rescue JSON::ParserError => e
-  warn "⚠️ Failed to parse JSON response for #{method.to_s.upcase} #{path} (status=#{res.code}): #{e.message}; body=#{res.body.to_s[0, 500].inspect}"
+  status = res&.code || 'unknown'
+  body_preview = res&.body.to_s[0, 500].inspect
+  warn "⚠️ Failed to parse JSON response for #{method.to_s.upcase} #{path} (status=#{status}): #{e.message}; body=#{body_preview}"
   parsed = {}
 ensure
-  return [res.code.to_i, parsed]
+  return [res&.code.to_i, parsed]
 end
 def get(p) = req(:get, p)
 

--- a/scripts/asc_autosubmit.rb
+++ b/scripts/asc_autosubmit.rb
@@ -34,30 +34,20 @@ TOKEN = JWT.encode({ iss: ISSUER_ID, iat: now, exp: now + 1100, aud: 'appstoreco
 BASE = 'https://api.appstoreconnect.apple.com'
 
 def req(method, path, body = nil)
-  res = nil
-  parsed = {}
-  res = nil
-  parsed = {}
-  res = nil
-  parsed = {}
   uri = URI("#{BASE}#{path}")
   klass = { get: Net::HTTP::Get, post: Net::HTTP::Post, patch: Net::HTTP::Patch }[method]
   raise ArgumentError, "Unsupported HTTP method: #{method.inspect}. Supported: :get, :post, :patch" unless klass
   r = klass.new(uri)
   r['Authorization'] = "Bearer #{TOKEN}"
   r['Content-Type'] = 'application/json'
-  warn "⚠️ Failed to parse JSON response for #{method.to_s.upcase} #{path} (status=#{res&.code || 'n/a'}): #{e.message}; body=#{res&.body.to_s[0, 500].inspect}"
+  r.body = JSON.generate(body) if body
   res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(r) }
-  status = res&.code || 'no-response'
-  return [res&.code.to_i, parsed]
-  warn "⚠️ Failed to parse JSON response for #{method.to_s.upcase} #{path} (status=#{status}): #{e.message}; body=#{body_preview.inspect}"
+  parsed = JSON.parse(res.body)
 rescue JSON::ParserError => e
-  status = res&.code || 'no-response'
-  return [(res&.code || 0).to_i, parsed]
-  warn "⚠️ Failed to parse JSON response for #{method.to_s.upcase} #{path} (status=#{status}): #{e.message}; body=#{body_preview}"
+  warn "⚠️ Failed to parse JSON response for #{method.to_s.upcase} #{path} (status=#{res.code}): #{e.message}; body=#{res.body.to_s[0, 500].inspect}"
   parsed = {}
 ensure
-  return [(res&.code || 0).to_i, parsed]
+  return [res.code.to_i, parsed]
 end
 def get(p) = req(:get, p)
 


### PR DESCRIPTION
## What
Restores the known-good `req()` in `scripts/asc_autosubmit.rb`. The Copilot Autofix "Fix for Potentially uninitialized local variable" commits (merged via PRs #256–#258) had mangled it.

## Why it matters (runtime-proven)
The mangled version on Master:
- triple-duplicated `res=nil`/`parsed={}`
- referenced an **undefined `e`** *before* the HTTP request → `NameError` on every call
- had unreachable `return`s + undefined `body_preview`

Result: **every ASC API call returned `[0,{}]` without contacting Apple** — so the runner's submit-to-review step silently did nothing. (Verified by executing it: returned `[0,{}]`, no request sent.)

## The fix
Single init; `r.body = JSON.generate(body) if body` (the dropped line that broke POST/PATCH); clean `rescue`/`ensure`.

## Verification done
- `ruby -c` → Syntax OK
- Full read workflow (build-fetch → version → IAPs) runs to `✅ DRY RUN complete` against **stubbed** ASC.
- **Not yet run against real Apple** (no .p8 here) — that happens when CI runs `ASC Submit (no rebuild)`, which holds the key.

## Note
Re-merging will revert again unless Copilot Autofix auto-merge is disabled (Settings → Code security → Copilot Autofix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling for more consistent results when processing HTTP responses.
  * Added safer handling for invalid JSON responses, including a warning log and a graceful fallback instead of failing outright.
  * Streamlined response parsing so the request method now returns a consistent status-and-data result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->