### PR TITLE
fix: app won't open — DashboardScreen Metro build + native SoLoader libc++_shared crash (1.5.9/546)

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "MarketingTool",
     "slug": "marketingtool",
     "owner": "aimarketintool-2-2-2",
-    "version": "1.5.8",
+    "version": "1.5.9",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",
@@ -19,7 +19,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "pro.marketingtool.app",
-      "buildNumber": "545",
+      "buildNumber": "546",
       "googleServicesFile": "./GoogleService-Info.plist",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
@@ -56,7 +56,7 @@
       },
       "googleServicesFile": "./google-services.json",
       "package": "pro.marketingtool.app",
-      "versionCode": 545,
+      "versionCode": 546,
       "allowBackup": false,
       "permissions": [
         "CAMERA",
@@ -124,7 +124,8 @@
             "targetSdkVersion": 36,
             "minSdkVersion": 24,
             "windowSoftInputMode": "adjustResize",
-            "useMemoryPageSize16KB": true,
+            "useLegacyPackaging": true,
+            "buildArchs": ["armeabi-v7a", "arm64-v8a"],
             "ndkVersion": "27.1.12297006",
             "kotlinVersion": "2.3.0",
             "kspVersion": "2.3.0"

--- a/plugins/withAndroidAbiFilters.js
+++ b/plugins/withAndroidAbiFilters.js
@@ -19,7 +19,7 @@ const withAndroidAbiFilters = (config) => {
 
     contents = contents.replace(
       /(versionCode\s+\d+\s*\n\s*versionName\s+"[^"]*"\s*\n)/,
-      `$1\n        ndk {\n            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64'\n        }\n`,
+      `$1\n        ndk {\n            abiFilters 'armeabi-v7a', 'arm64-v8a'\n        }\n`,
     );
 
     cfg.modResults.contents = contents;

--- a/plugins/withKotlinKspFix.js
+++ b/plugins/withKotlinKspFix.js
@@ -150,13 +150,13 @@ allprojects {
     }
 
     // 🚨 16 KB page size alignment fix
-    if (!contents.includes("useLegacyPackaging = false")) {
+    if (!contents.includes("useLegacyPackaging = true")) {
       contents = contents.replace(
         /android\s*\{/,
         `android {
     packagingOptions {
         jniLibs {
-            useLegacyPackaging = false
+            useLegacyPackaging = true
         }
     }`
       );

--- a/src/screens/main/DashboardScreen.tsx
+++ b/src/screens/main/DashboardScreen.tsx
@@ -25,8 +25,8 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../navigation/AppNavigator';
 import { hasProAccess, generationsLimitForTier } from '../../services/billingService';
-import { generationsLimitForTier } from '../../services/billingService';
 import { useAuthStore } from '../../store/authStore';
+import { useToolsStore, TOOL_CATEGORIES } from '../../store/toolsStore';
 import { Colors, Spacing, BorderRadius, HEADER_TOP_PADDING } from '../../constants/theme';
 import { getToolIcon } from '../../constants/toolIcons';
 import LottieView from 'lottie-react-native';
@@ -165,7 +165,9 @@ const AnimatedStatCard = ({ stat, index, onPress }: { stat: any; index: number; 
 
 const DashboardScreen = () => {
   const navigation = useNavigation<NavigationProp>();
-  const { user, profile, localSubscriptionOverride, generations } = useAuthStore();
+  const { user, profile, localSubscriptionOverride } = useAuthStore();
+  const { tools, fetchTools, isLoading, generations, fetchGenerations } = useToolsStore();
+  const [refreshing, setRefreshing] = React.useState(false);
   // and must win even when the server write failed (e.g. Apple's sandbox).
   const isFreeUser =
     (!profile?.subscription || profile.subscription === 'free') &&
@@ -179,11 +181,6 @@ const DashboardScreen = () => {
 
   useEffect(() => {
     fetchTools();
-  const fetchTools = async () => {
-    // TODO: wire existing tools retrieval logic here.
-    // Kept async so current `await fetchTools()` usage remains valid.
-  };
-
     // Fetch user generations when logged in
     if (user?.$id) {
       fetchGenerations(user.$id);


### PR DESCRIPTION
## What this fixes
Both platforms crash on launch ("click then close"). Two root causes, from real evidence:

**Bug 1 — build failed (Metro).** Autofix bots left a duplicate `generationsLimitForTier` import + dropped `useToolsStore`/`refreshing` in `DashboardScreen.tsx` → `Bundle JavaScript` SyntaxError. Every build 545 ERRORED (confirmed in EAS build logs). Restored.

**Bug 2 — native launch crash.** Crashlytics `b86794a`: `SoLoaderDSONotFoundError: libc++_shared.so` at `MainApplication.onCreate` (New-Arch init). `useLegacyPackaging=false` loaded .so uncompressed-from-APK; on Android-15 16KB devices libc++_shared.so wasn't found. Set `useLegacyPackaging: true` + `buildArchs: [armeabi-v7a, arm64-v8a]`; removed bogus `useMemoryPageSize16KB`.

## Proof
`bunx expo export --platform android` → exit 0, **0 errors**, `Android Bundled (2246 modules)`.

Bumps 1.5.8/545 → 1.5.9/546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard refresh behavior so content reloads more reliably.
  * Updated Android packaging and device support settings for smoother builds on supported devices.

* **Chores**
  * Bumped the app version and platform build numbers to the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->