### PR TITLE
fix(credits): free tier 10 → 3 (match pricing, kill the fake '10')

### DIFF
--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -100,7 +100,7 @@ export const hasProAccess = (profileTier?: string | null, override?: string | nu
 // profile.generationsLimit (which defaults to 10) — otherwise a Growth member
 // wrongly sees "0/10". Enterprise/Agency = effectively unlimited.
 export const TIER_GENERATIONS: Record<Tier, number> = {
-  free: 10,
+  free: 3,
   starter: 200,
   pro: 500,
   growth: 1500,

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -633,7 +633,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       email: user.email,
       subscription: 'free',
       generationsUsed: 0,
-      generationsLimit: 10,
+      generationsLimit: 3,
       createdAt: new Date().toISOString(),
     };
 
@@ -665,7 +665,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
             email: user.email,
             subscription: 'free',
             generationsUsed: 0,
-            generationsLimit: 10,
+            generationsLimit: 3,
             createdAt: new Date().toISOString(),
           }
         ),


### PR DESCRIPTION
Free tier showed **10** generations but pricing advertises the free trial as **3/day**. Set `TIER_GENERATIONS.free = 3` + profile fallbacks `generationsLimit 10→3`. Paid tiers unchanged (starter 200 / pro 500 / growth 1500 / enterprise unlimited) — verified against live Appwrite DB (a paying user = starter/200) and the pricing page.

Verified: `bunx expo export --platform android` → exit 0, 2246 modules, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default monthly generation limit for free accounts and newly created profiles from 10 to 3.
  * Usage limits shown in the app now reflect the lower free-tier allowance consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->