### PR TITLE
release: ship build 548 (v1.5.11) — unblock the crashing app

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "MarketingTool",
     "slug": "marketingtool",
     "owner": "aimarketintool-2-2-2",
-    "version": "1.5.9",
+    "version": "1.5.11",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",
@@ -19,11 +19,12 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "pro.marketingtool.app",
-      "buildNumber": "546",
+      "buildNumber": "548",
       "googleServicesFile": "./GoogleService-Info.plist",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "FirebaseAppDelegateProxyEnabled": true,
+        "GADApplicationIdentifier": "ca-app-pub-3940256099942544~1458002511",
         "CFBundleURLTypes": [
           {
             "CFBundleURLSchemes": [
@@ -56,7 +57,7 @@
       },
       "googleServicesFile": "./google-services.json",
       "package": "pro.marketingtool.app",
-      "versionCode": 546,
+      "versionCode": 548,
       "allowBackup": false,
       "permissions": [
         "CAMERA",


### PR DESCRIPTION
## Why
Master already has every crash + UX fix, but **no launchable build was ever shipped from it**:
- iOS AdMob `iosAppId` (stops `GADApplicationVerifyPublisherInitializedCorrectly`) ✅ already on Master
- react 19.2.3 / RN 0.85.3 / firebase 24.1.1 pins (stops Android `Incompatible React versions`) ✅
- `useLegacyPackaging` (stops Android `SoLoaderDSONotFoundError: libc++_shared.so`) ✅
- real credits + desktop-404 hand-off removed ✅

The blocker was purely the version: `eas.json` has `appVersionSource: local` + `autoIncrement: false`, and `app.json` was **buildNumber 546** while **547 was already uploaded to TestFlight (and 547 is the crashing build)**. A build from Master would be rejected as ≤ 547.

## Change (app.json only)
- version `1.5.9` → `1.5.11`
- ios.buildNumber `546` → `548` (> the used 547)
- android.versionCode `546` → `548`
- add `ios.infoPlist.GADApplicationIdentifier` (belt-and-suspenders next to the plugin `iosAppId`)

## Ship
Merge → push tag `v1.5.11` (or run `production-deploy.yml` with `both`) → runner builds + auto-submits **both platforms** via EAS cloud.

## ⚠️ Still requires runtime verification
Code-level fixes only. NOT build-verified. After the build: confirm the app launches on iPhone + Android and TestFlight/Crashlytics show zero `GADApplicationVerifyPublisherInitializedCorrectly`, `Incompatible React versions`, or `SoLoaderDSONotFoundError`.

Supersedes #269 (which was redundant with Master and conflicted only on dep files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)