### PR TITLE
chore(release): bump build to 550 for fresh both-platform deploy

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,7 +19,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "pro.marketingtool.app",
-      "buildNumber": "548",
+      "buildNumber": "550",
       "googleServicesFile": "./GoogleService-Info.plist",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
@@ -57,7 +57,7 @@
       },
       "googleServicesFile": "./google-services.json",
       "package": "pro.marketingtool.app",
-      "versionCode": 548,
+      "versionCode": 550,
       "allowBackup": false,
       "permissions": [
         "CAMERA",


### PR DESCRIPTION
Bumps iOS `buildNumber` + Android `versionCode` 548 → 550.

**Why:** 548 is already built on EAS. Master already carries the icon fix + AdMob crash fix. Building a fresh 550 from Master via **Production Deploy** ships those fixes on both platforms without a duplicate-number rejection.

**After merge:** Actions → **Production Deploy** → Run → **both** → builds + auto-submits iOS + Android (~1 hr to TestFlight/Play).

Note: source is fixed (git-verified); on-device rendering is confirmed by installing the TestFlight/Play build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s iOS build number and Android version code to `550` for the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->