### PR TITLE
fix(dashboard): remove duplicate 'generations' destructure (blocks eas update on Master)

### DIFF
--- a/src/screens/main/DashboardScreen.tsx
+++ b/src/screens/main/DashboardScreen.tsx
@@ -183,7 +183,7 @@ const DashboardScreen = () => {
   const { tools, fetchTools, isLoading, generations, fetchGenerations } = useToolsStore();
   const [refreshing, setRefreshing] = React.useState(false);
   // and must win even when the server write failed (e.g. Apple's sandbox).
-  const { user, profile, localSubscriptionOverride, generations } = useAuthStore();
+  const { user, profile, localSubscriptionOverride } = useAuthStore();
   const isFreeUser =
     (!profile?.subscription || profile.subscription === 'free') &&
     localSubscriptionOverride === 'free';


### PR DESCRIPTION
Metro dies bundling Master: `Identifier 'generations' has already been declared. (186:52)` in DashboardScreen.tsx — hit during the production OTA publish.

Line 183 destructures `generations` from `useToolsStore()` (where it exists: `toolsStore.ts:67`), line 186 destructured it AGAIN from `useAuthStore()` (which has no `generations` — only `generationsUsed`/`generationsLimit`). Removed the bogus authStore one; all usages (lines 194+) keep reading the toolsStore array.

Third duplicate-declaration bot artifact after 'tools' (OTA-fixed 2026-07-02) and DESKTOP_URL (#288). **Verified**: esbuild parse sweep of all 52 src/*.ts(x) files → 0 failures.

**Recommended follow-up** (I'm hook-blocked from editing workflows): add a blocking parse-check step to `.github/workflows/build-and-test.yml` after 'Install dependencies' —

```yaml
      - name: Parse check (blocks duplicate-declaration SyntaxErrors)
        run: |
          fails=0
          for f in $(git ls-files 'src/**/*.tsx' 'src/**/*.ts' 'App.tsx' 'index.ts'); do
            loader="${f##*.}"
            npx esbuild --loader:.${loader}=${loader} "$f" --outfile=/dev/null || { echo "::error file=$f::parse failed"; fails=$((fails+1)); }
          done
          exit $fails
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPuhGZh3jAo8UcuyeiXAPa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dashboard values and credit/count displays to use the correct generations source, helping keep visible totals consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->