### PR TITLE
ci: pin claude.yml actions to full SHAs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,13 +22,13 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |


### PR DESCRIPTION
## Why

Every push-triggered workflow in this repo is currently failing with `startup_failure` (0-2s, no jobs). Root cause is **not** in any workflow file: the repo's Actions permissions are set to **"Allow local actions only"** (`allowed_actions: local_only`), so any `uses:` of an external action — starting with `actions/checkout` — kills the run at plan time. Fixing that requires an admin change in **Settings → Actions → General → Actions permissions** (or the org-level equivalent); no PR can do it.

This PR fixes the *secondary* blocker: the repo also has `sha_pinning_required: true`, and `claude.yml` still used tag refs. Once the allowed-actions policy is corrected, `claude.yml` would keep failing on unpinned refs.

## What

- `actions/checkout@v7` → `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` (v7.0.0, same pin the other workflows use)
- `anthropics/claude-code-action@v1` → `anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a` (commit the `v1` tag currently dereferences to)

Both SHAs verified against the upstream repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUy3cbxfWfmzJC4a2Lj66d