### PR TITLE
fix: dedupe buildNumber/versionCode again (merge resolution re-added 557/556 → effective 556)

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,8 +20,6 @@
       "supportsTablet": true,
       "bundleIdentifier": "pro.marketingtool.app",
       "buildNumber": "558",
-      "buildNumber": "557",
-      "buildNumber": "556",
       "googleServicesFile": "./GoogleService-Info.plist",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
@@ -60,8 +58,6 @@
       "googleServicesFile": "./google-services.json",
       "package": "pro.marketingtool.app",
       "versionCode": 558,
-      "versionCode": 557,
-      "versionCode": 556,
       "allowBackup": false,
       "permissions": [
         "CAMERA",


### PR DESCRIPTION
The #307 merge conflict resolution kept both sides in app.json, re-adding the `557`/`556` duplicate lines under the `558` ones. JSON last-key-wins means a build dispatched from Master right now would carry **versionCode 556** — below the live 557 — and be rejected by Play.

This removes the 4 stale lines. Effective values verified: **buildNumber 558 / versionCode 558**, version 1.5.11.

**Merge this before dispatching the Android build.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew8aPCnzwp82bUNed6VdyL