### PR TITLE
Fix for Assignment to constant

### DIFF
--- a/src/screens/tools/ToolResultScreen.tsx
+++ b/src/screens/tools/ToolResultScreen.tsx
@@ -120,12 +120,6 @@ const ToolResultScreen = () => {
     );
   };
 
-  // Desktop hand-off per MOBILE_TOOLS_POLICY.md (owner decision 2026-06-28):
-  // the button opens the owner's web app (app.marketingtool.pro — owner confirmed
-  // 2026-07-05 the web app is fixed and serving again). Opened IN-APP via
-  // SFSafariViewController/Custom Tabs so the app never backgrounds (backgrounding
-  // read as "app closed" to users on both platforms).
-  const DESKTOP_URL = 'https://app.marketingtool.pro/login';
   // Desktop hand-off per MOBILE_TOOLS_POLICY.md (owner decision 2026-06-28).
   // The SPA at app.marketingtool.pro currently client-renders a 404 on EVERY route
   // (device-verified 2026-07-04: the web app crashes on load; fix is PR #30 on the


### PR DESCRIPTION
To fix this without changing functionality, keep a single `DESKTOP_URL` declaration and remove the earlier conflicting one. Given the nearby comments state that the SPA is currently broken and the temporary target should be `https://marketingtool.pro`, the best fix is to preserve the second value and delete the first declaration (`https://app.marketingtool.pro/login`).

In `src/screens/tools/ToolResultScreen.tsx`, edit the desktop hand-off section (around lines 123–137): remove the first `const DESKTOP_URL = 'https://app.marketingtool.pro/login';` line and keep only one `const DESKTOP_URL = 'https://marketingtool.pro';` before `handleViewOnDesktop`. No import, method, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the “View Full on Desktop” action to open the working desktop site.
  - Prevented the action from leading to an invalid page or application error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->