### PR TITLE
Potential fix for code scanning alert no. 419: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -9,6 +9,9 @@ name: Deploy to Firebase Hosting on merge
 # Re-add `push: branches: [Master]` only if the phone repo should publish web.
 on:
   workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Lokeninfinitypoint/AiMarketingtool-pro-fbaf2fad/security/code-scanning/419](https://github.com/Lokeninfinitypoint/AiMarketingtool-pro-fbaf2fad/security/code-scanning/419)

Add an explicit `permissions` block in `.github/workflows/firebase-hosting-merge.yml` at the workflow root, directly under `on:` (or under `name:`/before `jobs:`).  
Best minimal fix without changing intended functionality is:

- `contents: read` (required baseline for checkout and read access)
- `pull-requests: write` (commonly needed by Firebase hosting deploy action when using `repoToken` to comment/update PR-related metadata; safe to keep explicit at least privilege relative to broad defaults)

This keeps behavior compatible while removing reliance on potentially over-privileged defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
