### PR TITLE
ci: pin remaining tag-based action refs to full commit SHAs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -15,7 +15,7 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Set up Ruby 3.3
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):

--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -23,7 +23,7 @@ jobs:
       digests: ${{ steps.hash.outputs.digests }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # ========================================================
       #

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@f7176fd3007623b69d27091f9b9d4ab7995f0a06 # v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue message'


### PR DESCRIPTION
Follow-up to the CI failures where actions were rejected as *"not allowed … because all actions must be from a repository owned by Marketingtool-pro and pinned to a full-length commit SHA."*

## ⚠️ This PR alone does not unblock CI

The error has **two** independent causes, and only one of them is fixable in code:

| Cause | Fixable here? |
|---|---|
| Refs not pinned to a full-length SHA | ✅ this PR |
| Actions not owned by `Marketingtool-pro` | ❌ **org setting** |

The second error in the report lists actions that were **already** full-SHA-pinned (`actions/checkout@9c091bb…`, `jdx/mise-action@e6a8b39…`, `actions/setup-node@48b55a0…`, `expo/expo-github-action@eab7a23…`) and they were *still* rejected — because none of them are owned by the org. Every action in this repo is third-party, so **CI stays broken until non-org actions are allow-listed** at https://github.com/organizations/Marketingtool-pro/settings/actions → "Actions permissions".

Allow-list entries needed for the non-GitHub-owned actions currently in use:

```
expo/expo-github-action@*
anthropics/claude-code-action@*
ruby/setup-ruby@*
jdx/mise-action@*
FirebaseExtended/action-hosting-deploy@*
google-github-actions/auth@*
slsa-framework/slsa-github-generator/*@*
```

Ticking **"Allow actions created by GitHub"** covers the rest (`actions/checkout`, `actions/setup-node`, `actions/setup-java`, `actions/stale`, `actions/upload-artifact`, `actions/ai-inference`, `github/codeql-action`).

## What this PR changes

Six live refs were still on mutable tags:

| ref | pinned to | files |
|---|---|---|
| `actions/checkout@v4` | `11d5960a` | `claude.yml`, `claude-code-review.yml`, `gem-push.yml`, `generator-generic-ossf-slsa3-publish.yml` |
| `anthropics/claude-code-action@v1` | `be7b93b1` | `claude.yml`, `claude-code-review.yml` |
| `actions/stale@v5` | `f7176fd3` | `stale.yml` |

Each tag was resolved to **its own** current SHA via the API, rather than normalised onto the `actions/checkout` SHA already used 17× elsewhere (`9c091bb…`). That SHA is a *different* ref — reusing it would have silently changed major version. Version comments (`# v4`) are retained for readability.

## Deliberately left on a tag

- **`slsa-framework/slsa-github-generator/…@v1.4.0`** — the SLSA generator verifies its own ref and **refuses to run from a bare SHA**. It must stay on a tag and needs an allow-list entry instead. Pinning it would have broken provenance generation.

## Not touched — inert, despite showing up in a grep

- `ruby/setup-ruby@v1` (`gem-push.yml:22`) — commented out; the active ref on line 23 is already SHA-pinned.
- `actions/setup-example@v1` (`codeql.yml:74`) — commented out, **and the repo does not exist upstream** (API returns 404). Leftover template scaffolding.
- `codeql.yml.bak` — not a file GitHub evaluates.

## Test

- All 5 modified workflows parse: `YAML.safe_load` → ok
- No live tag refs remain except the SLSA one noted above
- Diff is 7 lines, all `uses:` values

## Observation, not changed here

There is pin drift worth a separate cleanup: `actions/checkout` appears on 3 different SHAs, `actions/setup-node` on 3, and `github/codeql-action/init` on 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGMzbTTT7mLfTxCQkcn4Zf
