### PR TITLE
fix(release): bump versionCode/buildNumber to 1001

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,7 +19,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "pro.marketingtool.app",
-      "buildNumber": "1000",
+      "buildNumber": "1001",
       "googleServicesFile": "./GoogleService-Info.plist",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
@@ -57,7 +57,7 @@
       },
       "googleServicesFile": "./google-services.json",
       "package": "pro.marketingtool.app",
-      "versionCode": 1000,
+      "versionCode": 1001,
       "allowBackup": false,
       "permissions": [
         "CAMERA",

--- a/plugins/withKotlinKspFix.js
+++ b/plugins/withKotlinKspFix.js
@@ -106,6 +106,11 @@ allprojects {
             if (requested.group == 'androidx.core' && (requested.name == 'core-ktx' || requested.name == 'core')) {
                 details.useVersion '1.17.0'
             }
+            // These two are still held at SDK 35-era versions while core is now
+            // 1.17.0 above, so the set is deliberately mismatched. They compile
+            // under compileSdk 36, but activity 1.10.x predates Android 16's
+            // enforced edge-to-edge. If an API 36 build regresses on edge-to-edge
+            // or window insets, raise these before looking anywhere else.
             if (requested.group == 'androidx.activity') {
                 details.useVersion '1.10.1'
             }


### PR DESCRIPTION
Follow-up to #333, which was squash-merged before this landed.

#333 removed the duplicate JSON keys and so restored the intended `1000`. But your Expo build history shows a **1.5.11 (1000) production build already succeeded** 20 days ago from `2e62a02`, and this project has a Google service account for EAS Submit (`eas-submit@marketing-tool-484720`) — so `ship:android --auto-submit` really does push to Play. If 1000 was submitted, reusing it gets rejected as an already-used version code.

Version codes only need to **increase** — gaps are harmless — so `1001` is correct whether or not 1000 reached Play. iOS `buildNumber` bumped to match, since the same duplicate-key bug had knocked both back to 559.

Also restores a warning comment that the Copilot autofix on `66b487bb` removed. That autofix was right to raise `androidx.core` to 1.17.0 for `expo-dev-launcher`s `WindowCompat.enableEdgeToEdge()` — but it only raised `core`. `androidx.activity` is still `1.10.1` and `androidx.browser` still `1.8.0`, so the set is now deliberately mismatched against core 1.17.0. Versions are left alone (unverifiable without a full Gradle build), but the note records where to look first if an API 36 build regresses on edge-to-edge or insets.

## Test

- `app.json` parses, single `versionCode`/`buildNumber` key each, both `1001`
- `withKotlinKspFix.js` loads under node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGMzbTTT7mLfTxCQkcn4Zf