### PR TITLE
fix(ci): trigger production-deploy on published releases

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -16,6 +16,13 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  # Publishing a GitHub Release creates its tag as part of the publish, which
+  # does not emit the tag `push` event above. v1.6.11 was drafted on 2026-07-11
+  # and published on 2026-07-13 that way, so this workflow never fired for it --
+  # it has never run once. Listening for `published` covers releases made in the
+  # UI (including pre-releases, which `released` would skip).
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       platforms:


### PR DESCRIPTION
You reported the v1.6.11 release not building. There are **two independent causes**, and this PR fixes the second one.

## Cause 1 — nothing runs at all (org setting, not fixable in code)

Every recent workflow run is **`startup_failure`**:

```
startup_failure  push          Master                 CodeQL Advanced
startup_failure  push          Master                 Ruby Gem
startup_failure  push          Master                 Build and Test
startup_failure  pull_request  fix/versioncode-1001   Claude Code Review
startup_failure  issue_comment Master                 Claude Code
```

`startup_failure` means the run never even began — which is exactly what the org Actions policy produces. The only green entries are `dynamic` events (Copilot / Code Quality), which aren't Actions workflows. **Until non-org-owned actions are allow-listed, nothing in this repo can build**, including this fix.

## Cause 2 — the deploy never fires on a release (this PR)

`production-deploy.yml` has **never run once**, despite existing since 2026-03-09 and despite `v1.6.11` matching its `v*.*.*` filter. Confirmed:

- its only triggers were `push: tags: ['v*.*.*']` and `workflow_dispatch`
- `gh run list --workflow=production-deploy.yml` → **empty**
- runs ever triggered by a `release` event, across all workflows → **0**
- `v1.6.11` → commit `020fa28b`, and `production-deploy.yml` **is** present at that tag, so the file wasn't missing
- the tag is lightweight (no tagger), and the release was `created=2026-07-11`, `published=2026-07-13` by `Lokeninfinitypoint` — **drafted, then published two days later**

A tag brought into existence by publishing a GitHub Release doesn't emit the tag `push` event this workflow was waiting for. So it sat idle.

### The fix

Added `release: types: [published]`.

`published` rather than `released` is deliberate — **v1.6.11 is a pre-release**, and `released` skips pre-releases.

**No job changes were needed.** All three jobs gate on `startsWith(github.ref, 'refs/tags/v')`, and on a release event `github.ref` is `refs/tags/<tag>`, so every guard already passes. Verified against the parsed YAML:

```
triggers: push, release, workflow_dispatch
release types: ["published"]
build-android:    guard ok = true
submit-android:   guard ok = true
build-submit-ios: guard ok = true
```

The existing `concurrency` group keys on `github.ref`, identical for both trigger paths, so a git-pushed tag plus a UI release won't double-build.

## ⚠️ Version incoherence — needs your decision, not changed here

The tag says **v1.6.11**, but on Master:

| file | version |
|---|---|
| `app.json` | **1.5.11** |
| `package.json` | **1.5.7** |

The build takes its version from `app.json`, so even a successful v1.6.11 deploy would ship a binary labelled **1.5.11**. Three different numbers. Which is authoritative is a release decision, so I've left it alone — tell me the intended version and I'll align them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGMzbTTT7mLfTxCQkcn4Zf
