### PR TITLE
fix(auth): phone sign-in for all countries, and close the OTP bypass

### DIFF
--- a/src/data/countries.ts
+++ b/src/data/countries.ts
@@ -1,0 +1,285 @@
+/**
+ * E.164 dialling codes for phone sign-in.
+ *
+ * The picker previously shipped four entries (US, India, Canada, UK), which
+ * meant users anywhere else could not select their dialling code and therefore
+ * could never receive an OTP. This is the full list so sign-in works in every
+ * market the app is distributed in.
+ *
+ * Flags are derived from the ISO 3166-1 alpha-2 code rather than hardcoded, so
+ * the table stays compact and a flag can never drift out of sync with its
+ * country.
+ */
+
+export interface Country {
+  name: string;
+  /** ISO 3166-1 alpha-2. Stable identity -- dialling codes are NOT unique
+   *  (+1 covers the US, Canada and much of the Caribbean; +44 covers the UK,
+   *  Jersey, Guernsey and the Isle of Man), so prefer this as the key. */
+  iso: string;
+  /** E.164 dialling prefix, including the leading '+'. */
+  code: string;
+  flag: string;
+}
+
+/** Regional indicator symbols: 'IN' -> 🇮🇳 */
+function flagOf(iso: string): string {
+  return iso
+    .toUpperCase()
+    .replace(/./g, (ch) => String.fromCodePoint(0x1f1e6 - 65 + ch.charCodeAt(0)));
+}
+
+// [name, iso2, dialling code]
+const TABLE: [string, string, string][] = [
+  ['Afghanistan', 'AF', '+93'],
+  ['Albania', 'AL', '+355'],
+  ['Algeria', 'DZ', '+213'],
+  ['American Samoa', 'AS', '+1684'],
+  ['Andorra', 'AD', '+376'],
+  ['Angola', 'AO', '+244'],
+  ['Anguilla', 'AI', '+1264'],
+  ['Antigua and Barbuda', 'AG', '+1268'],
+  ['Argentina', 'AR', '+54'],
+  ['Armenia', 'AM', '+374'],
+  ['Aruba', 'AW', '+297'],
+  ['Australia', 'AU', '+61'],
+  ['Austria', 'AT', '+43'],
+  ['Azerbaijan', 'AZ', '+994'],
+  ['Bahamas', 'BS', '+1242'],
+  ['Bahrain', 'BH', '+973'],
+  ['Bangladesh', 'BD', '+880'],
+  ['Barbados', 'BB', '+1246'],
+  ['Belarus', 'BY', '+375'],
+  ['Belgium', 'BE', '+32'],
+  ['Belize', 'BZ', '+501'],
+  ['Benin', 'BJ', '+229'],
+  ['Bermuda', 'BM', '+1441'],
+  ['Bhutan', 'BT', '+975'],
+  ['Bolivia', 'BO', '+591'],
+  ['Bosnia and Herzegovina', 'BA', '+387'],
+  ['Botswana', 'BW', '+267'],
+  ['Brazil', 'BR', '+55'],
+  ['British Virgin Islands', 'VG', '+1284'],
+  ['Brunei', 'BN', '+673'],
+  ['Bulgaria', 'BG', '+359'],
+  ['Burkina Faso', 'BF', '+226'],
+  ['Burundi', 'BI', '+257'],
+  ['Cambodia', 'KH', '+855'],
+  ['Cameroon', 'CM', '+237'],
+  ['Canada', 'CA', '+1'],
+  ['Cape Verde', 'CV', '+238'],
+  ['Cayman Islands', 'KY', '+1345'],
+  ['Central African Republic', 'CF', '+236'],
+  ['Chad', 'TD', '+235'],
+  ['Chile', 'CL', '+56'],
+  ['China', 'CN', '+86'],
+  ['Colombia', 'CO', '+57'],
+  ['Comoros', 'KM', '+269'],
+  ['Congo - Brazzaville', 'CG', '+242'],
+  ['Congo - Kinshasa', 'CD', '+243'],
+  ['Cook Islands', 'CK', '+682'],
+  ['Costa Rica', 'CR', '+506'],
+  ["Côte d'Ivoire", 'CI', '+225'],
+  ['Croatia', 'HR', '+385'],
+  ['Cuba', 'CU', '+53'],
+  ['Curaçao', 'CW', '+599'],
+  ['Cyprus', 'CY', '+357'],
+  ['Czechia', 'CZ', '+420'],
+  ['Denmark', 'DK', '+45'],
+  ['Djibouti', 'DJ', '+253'],
+  ['Dominica', 'DM', '+1767'],
+  ['Dominican Republic', 'DO', '+1809'],
+  ['Ecuador', 'EC', '+593'],
+  ['Egypt', 'EG', '+20'],
+  ['El Salvador', 'SV', '+503'],
+  ['Equatorial Guinea', 'GQ', '+240'],
+  ['Eritrea', 'ER', '+291'],
+  ['Estonia', 'EE', '+372'],
+  ['Eswatini', 'SZ', '+268'],
+  ['Ethiopia', 'ET', '+251'],
+  ['Fiji', 'FJ', '+679'],
+  ['Finland', 'FI', '+358'],
+  ['France', 'FR', '+33'],
+  ['French Guiana', 'GF', '+594'],
+  ['French Polynesia', 'PF', '+689'],
+  ['Gabon', 'GA', '+241'],
+  ['Gambia', 'GM', '+220'],
+  ['Georgia', 'GE', '+995'],
+  ['Germany', 'DE', '+49'],
+  ['Ghana', 'GH', '+233'],
+  ['Gibraltar', 'GI', '+350'],
+  ['Greece', 'GR', '+30'],
+  ['Greenland', 'GL', '+299'],
+  ['Grenada', 'GD', '+1473'],
+  ['Guadeloupe', 'GP', '+590'],
+  ['Guam', 'GU', '+1671'],
+  ['Guatemala', 'GT', '+502'],
+  ['Guernsey', 'GG', '+44'],
+  ['Guinea', 'GN', '+224'],
+  ['Guinea-Bissau', 'GW', '+245'],
+  ['Guyana', 'GY', '+592'],
+  ['Haiti', 'HT', '+509'],
+  ['Honduras', 'HN', '+504'],
+  ['Hong Kong', 'HK', '+852'],
+  ['Hungary', 'HU', '+36'],
+  ['Iceland', 'IS', '+354'],
+  ['India', 'IN', '+91'],
+  ['Indonesia', 'ID', '+62'],
+  ['Iran', 'IR', '+98'],
+  ['Iraq', 'IQ', '+964'],
+  ['Ireland', 'IE', '+353'],
+  ['Isle of Man', 'IM', '+44'],
+  ['Israel', 'IL', '+972'],
+  ['Italy', 'IT', '+39'],
+  ['Jamaica', 'JM', '+1876'],
+  ['Japan', 'JP', '+81'],
+  ['Jersey', 'JE', '+44'],
+  ['Jordan', 'JO', '+962'],
+  ['Kazakhstan', 'KZ', '+7'],
+  ['Kenya', 'KE', '+254'],
+  ['Kiribati', 'KI', '+686'],
+  ['Kosovo', 'XK', '+383'],
+  ['Kuwait', 'KW', '+965'],
+  ['Kyrgyzstan', 'KG', '+996'],
+  ['Laos', 'LA', '+856'],
+  ['Latvia', 'LV', '+371'],
+  ['Lebanon', 'LB', '+961'],
+  ['Lesotho', 'LS', '+266'],
+  ['Liberia', 'LR', '+231'],
+  ['Libya', 'LY', '+218'],
+  ['Liechtenstein', 'LI', '+423'],
+  ['Lithuania', 'LT', '+370'],
+  ['Luxembourg', 'LU', '+352'],
+  ['Macao', 'MO', '+853'],
+  ['Madagascar', 'MG', '+261'],
+  ['Malawi', 'MW', '+265'],
+  ['Malaysia', 'MY', '+60'],
+  ['Maldives', 'MV', '+960'],
+  ['Mali', 'ML', '+223'],
+  ['Malta', 'MT', '+356'],
+  ['Marshall Islands', 'MH', '+692'],
+  ['Martinique', 'MQ', '+596'],
+  ['Mauritania', 'MR', '+222'],
+  ['Mauritius', 'MU', '+230'],
+  ['Mexico', 'MX', '+52'],
+  ['Micronesia', 'FM', '+691'],
+  ['Moldova', 'MD', '+373'],
+  ['Monaco', 'MC', '+377'],
+  ['Mongolia', 'MN', '+976'],
+  ['Montenegro', 'ME', '+382'],
+  ['Montserrat', 'MS', '+1664'],
+  ['Morocco', 'MA', '+212'],
+  ['Mozambique', 'MZ', '+258'],
+  ['Myanmar', 'MM', '+95'],
+  ['Namibia', 'NA', '+264'],
+  ['Nauru', 'NR', '+674'],
+  ['Nepal', 'NP', '+977'],
+  ['Netherlands', 'NL', '+31'],
+  ['New Caledonia', 'NC', '+687'],
+  ['New Zealand', 'NZ', '+64'],
+  ['Nicaragua', 'NI', '+505'],
+  ['Niger', 'NE', '+227'],
+  ['Nigeria', 'NG', '+234'],
+  ['North Korea', 'KP', '+850'],
+  ['North Macedonia', 'MK', '+389'],
+  ['Norway', 'NO', '+47'],
+  ['Oman', 'OM', '+968'],
+  ['Pakistan', 'PK', '+92'],
+  ['Palau', 'PW', '+680'],
+  ['Palestine', 'PS', '+970'],
+  ['Panama', 'PA', '+507'],
+  ['Papua New Guinea', 'PG', '+675'],
+  ['Paraguay', 'PY', '+595'],
+  ['Peru', 'PE', '+51'],
+  ['Philippines', 'PH', '+63'],
+  ['Poland', 'PL', '+48'],
+  ['Portugal', 'PT', '+351'],
+  ['Puerto Rico', 'PR', '+1787'],
+  ['Qatar', 'QA', '+974'],
+  ['Réunion', 'RE', '+262'],
+  ['Romania', 'RO', '+40'],
+  ['Russia', 'RU', '+7'],
+  ['Rwanda', 'RW', '+250'],
+  ['Saint Kitts and Nevis', 'KN', '+1869'],
+  ['Saint Lucia', 'LC', '+1758'],
+  ['Saint Vincent and the Grenadines', 'VC', '+1784'],
+  ['Samoa', 'WS', '+685'],
+  ['San Marino', 'SM', '+378'],
+  ['São Tomé and Príncipe', 'ST', '+239'],
+  ['Saudi Arabia', 'SA', '+966'],
+  ['Senegal', 'SN', '+221'],
+  ['Serbia', 'RS', '+381'],
+  ['Seychelles', 'SC', '+248'],
+  ['Sierra Leone', 'SL', '+232'],
+  ['Singapore', 'SG', '+65'],
+  ['Sint Maarten', 'SX', '+1721'],
+  ['Slovakia', 'SK', '+421'],
+  ['Slovenia', 'SI', '+386'],
+  ['Solomon Islands', 'SB', '+677'],
+  ['Somalia', 'SO', '+252'],
+  ['South Africa', 'ZA', '+27'],
+  ['South Korea', 'KR', '+82'],
+  ['South Sudan', 'SS', '+211'],
+  ['Spain', 'ES', '+34'],
+  ['Sri Lanka', 'LK', '+94'],
+  ['Sudan', 'SD', '+249'],
+  ['Suriname', 'SR', '+597'],
+  ['Sweden', 'SE', '+46'],
+  ['Switzerland', 'CH', '+41'],
+  ['Syria', 'SY', '+963'],
+  ['Taiwan', 'TW', '+886'],
+  ['Tajikistan', 'TJ', '+992'],
+  ['Tanzania', 'TZ', '+255'],
+  ['Thailand', 'TH', '+66'],
+  ['Timor-Leste', 'TL', '+670'],
+  ['Togo', 'TG', '+228'],
+  ['Tonga', 'TO', '+676'],
+  ['Trinidad and Tobago', 'TT', '+1868'],
+  ['Tunisia', 'TN', '+216'],
+  ['Türkiye', 'TR', '+90'],
+  ['Turkmenistan', 'TM', '+993'],
+  ['Turks and Caicos Islands', 'TC', '+1649'],
+  ['Tuvalu', 'TV', '+688'],
+  ['Uganda', 'UG', '+256'],
+  ['Ukraine', 'UA', '+380'],
+  ['United Arab Emirates', 'AE', '+971'],
+  ['United Kingdom', 'GB', '+44'],
+  ['United States', 'US', '+1'],
+  ['Uruguay', 'UY', '+598'],
+  ['Uzbekistan', 'UZ', '+998'],
+  ['Vanuatu', 'VU', '+678'],
+  ['Vatican City', 'VA', '+379'],
+  ['Venezuela', 'VE', '+58'],
+  ['Vietnam', 'VN', '+84'],
+  ['Yemen', 'YE', '+967'],
+  ['Zambia', 'ZM', '+260'],
+  ['Zimbabwe', 'ZW', '+263'],
+];
+
+export const COUNTRIES: Country[] = TABLE.map(([name, iso, code]) => ({
+  name,
+  iso,
+  code,
+  flag: flagOf(iso),
+}));
+
+/** Default selection. Looked up by ISO rather than array index so reordering
+ *  or adding countries can never silently change the default. */
+export const DEFAULT_COUNTRY: Country =
+  COUNTRIES.find((c) => c.iso === 'IN') ?? COUNTRIES[0];
+
+/**
+ * Resolve a persisted selection back to a Country.
+ *
+ * Prefers ISO because dialling codes are not unique -- looking up '+1' by code
+ * alone returns American Samoa (first alphabetically), which would silently
+ * change a US or Canadian user's country on session restore.
+ */
+export function findCountry(iso?: string, code?: string): Country | undefined {
+  if (iso) {
+    const byIso = COUNTRIES.find((c) => c.iso === iso);
+    if (byIso) return byIso;
+  }
+  if (code) return COUNTRIES.find((c) => c.code === code);
+  return undefined;
+}

--- a/src/data/countries.ts
+++ b/src/data/countries.ts
@@ -272,8 +272,8 @@ export const DEFAULT_COUNTRY: Country =
  * Resolve a persisted selection back to a Country.
  *
  * Prefers ISO because dialling codes are not unique -- looking up '+1' by code
- * alone returns American Samoa (first alphabetically), which would silently
- * change a US or Canadian user's country on session restore.
+ * alone returns Canada (the first matching exact '+1' entry), which could
+ * silently change a US user's country on session restore.
  */
 export function findCountry(iso?: string, code?: string): Country | undefined {
   if (iso) {

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -27,24 +27,15 @@ import { Colors, Spacing } from '../../constants/theme';
 import AnimatedBackground from '../../components/common/AnimatedBackground';
 import { biometricService, BiometricType } from '../../services/biometric';
 import { clearVerification as clearFirebaseVerification } from '../../services/firebaseAuth';
+import { COUNTRIES, DEFAULT_COUNTRY, findCountry, type Country } from '../../data/countries';
 
 import * as AppleAuthentication from 'expo-apple-authentication';
 
 
 
-// Country data for phone login
-interface Country {
-  name: string;
-  code: string;
-  flag: string;
-}
-
-const COUNTRIES: Country[] = [
-  { name: 'United States', code: '+1', flag: '🇺🇸' },
-  { name: 'India', code: '+91', flag: '🇮🇳' },
-  { name: 'Canada', code: '+1', flag: '🇨🇦' },
-  { name: 'United Kingdom', code: '+44', flag: '🇬🇧' },
-];
+// Country data for phone login. Previously a hardcoded four-entry list, which
+// left users outside the US/India/Canada/UK unable to pick their dialling code
+// -- and therefore unable to receive an OTP at all. See src/data/countries.ts.
 
 type NavigationProp = NativeStackNavigationProp<AuthStackParamList>;
 
@@ -60,7 +51,7 @@ const LoginScreen = () => {
   const [password, setPassword] = useState('');
   const [showEmailModal, setShowEmailModal] = useState(false);
   const [showCountryPicker, setShowCountryPicker] = useState(false);
-  const [selectedCountry, setSelectedCountry] = useState<Country>(COUNTRIES[1]);
+  const [selectedCountry, setSelectedCountry] = useState<Country>(DEFAULT_COUNTRY);
   const [phoneNumber, setPhoneNumber] = useState('');
   const [otpCode, setOtpCode] = useState('');
   const [totpCode, setTotpCode] = useState('');
@@ -158,11 +149,13 @@ const LoginScreen = () => {
     SecureStore.getItemAsync('pendingOTP').then(pending => {
       if (pending) {
         try {
-          const { phone, countryCode } = JSON.parse(pending);
+          const { phone, countryCode, countryIso } = JSON.parse(pending);
           setPhoneNumber(phone);
           setOtpSent(true);
           setShowOtpModal(true);
-          const country = COUNTRIES.find(c => c.code === countryCode);
+          // Resolve by ISO first: dialling codes aren't unique, so looking up
+          // '+1' by code alone would restore the wrong country.
+          const country = findCountry(countryIso, countryCode);
           if (country) setSelectedCountry(country);
         } catch {}
       }
@@ -175,11 +168,11 @@ const LoginScreen = () => {
         SecureStore.getItemAsync('pendingOTP').then(pending => {
           if (pending) {
             try {
-              const { phone, countryCode } = JSON.parse(pending);
+              const { phone, countryCode, countryIso } = JSON.parse(pending);
               setPhoneNumber(phone);
               setOtpSent(true);
               setShowOtpModal(true);
-              const country = COUNTRIES.find(c => c.code === countryCode);
+              const country = findCountry(countryIso, countryCode);
               if (country) setSelectedCountry(country);
             } catch {}
           }
@@ -224,6 +217,7 @@ const LoginScreen = () => {
     await SecureStore.setItemAsync('pendingOTP', JSON.stringify({
       phone: phoneNumber,
       countryCode: selectedCountry.code,
+      countryIso: selectedCountry.iso,
     }));
 
     try {

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -90,6 +90,30 @@ interface AuthState {
   fetchOrCreateProfile: (user: Models.User<Models.Preferences>) => Promise<UserProfile>;
 }
 
+/**
+ * Store-review OTP bypass check.
+ *
+ * Deliberately strict, because this branch skips SMS verification entirely:
+ *
+ *  - Matches the FULL E.164 number. The previous implementation compared only
+ *    the last 10 digits, which meant any number ending in the reviewer's last
+ *    10 digits -- in any of the ~200 supported dialling codes -- could skip OTP.
+ *  - Requires BOTH EXPO_PUBLIC_REVIEWER_PHONE and EXPO_PUBLIC_REVIEWER_OTP to
+ *    be set. There are no hardcoded fallbacks, so the bypass is inert in any
+ *    build that does not explicitly configure it.
+ *
+ * Note this is still a client-side check, and EXPO_PUBLIC_* values are inlined
+ * into the JS bundle at build time. Configure it only for the build handed to
+ * store review; the durable fix is to move the reviewer session server-side
+ * (the Appwrite phone-session function) so no bypass ships to users at all.
+ */
+function isReviewerPhone(e164: string): boolean {
+  const phone = process.env.EXPO_PUBLIC_REVIEWER_PHONE?.trim();
+  const code = process.env.EXPO_PUBLIC_REVIEWER_OTP?.trim();
+  if (!phone || !code) return false;
+  return e164 === `+${phone.replace(/\D/g, '')}`;
+}
+
 export const useAuthStore = create<AuthState>((set, get) => ({
   user: null,
   profile: null,
@@ -321,18 +345,22 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     // Android automatically. firebaseAuth service is in services/firebaseAuth.ts.
     set({ error: null });
     try {
-      const cleaned = phoneNumber.replace(/\D/g, '');
-      const formatted = phoneNumber.startsWith('+') ? `+${cleaned}` : `+91${cleaned}`;
+      // The login UI always prepends the selected dialling code, so a number
+      // without '+' means the country was lost upstream. Guessing (this used to
+      // default to '+91') silently routes a non-Indian user's OTP to a wrong
+      // number, so refuse rather than mis-deliver.
+      if (!phoneNumber.trim().startsWith('+')) {
+        throw new Error('Please select your country code and re-enter your number.');
+      }
+      const formatted = `+${phoneNumber.replace(/\D/g, '')}`;
 
-      // Reviewer bypass — App Store/Play review team uses a fixed test number.
-      // Prefer EXPO_PUBLIC_REVIEWER_PHONE from .env / EAS secrets, but this code
-      // also falls back to a hardcoded default review number if the env var is unset.
-      const reviewerPhone = process.env.EXPO_PUBLIC_REVIEWER_PHONE || '+919999999999';
-      const cleanFormatted = formatted.replace(/\D/g, '');
-      const cleanReviewer = reviewerPhone.replace(/\D/g, '');
-      
-      // Match if the last 10 digits are the same (handles +1 vs +91 vs no prefix)
-      const isReviewer = cleanFormatted.endsWith(cleanReviewer.slice(-10)) || formatted === reviewerPhone;
+      // Reviewer bypass for store review (App Store Guideline 2.1(b)).
+      // Inert unless BOTH env vars are explicitly set, and matched on the FULL
+      // number. The previous check compared only the last 10 digits, so any
+      // number ending in those digits -- in any supported country -- skipped
+      // OTP entirely. The hardcoded '+919999999999' fallback also meant the
+      // bypass stayed live even with no configuration at all.
+      const isReviewer = isReviewerPhone(formatted);
 
       if (isReviewer) {
         if (__DEV__) console.log('[Auth] Reviewer bypass active for', formatted);
@@ -362,20 +390,20 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         throw new Error('Verification session expired. Please request a new code.');
       }
 
-      const cleaned = rawPhone.replace(/\D/g, '');
-      const phone = rawPhone.startsWith('+') ? `+${cleaned}` : `+91${cleaned}`;
+      // rawPhone comes from tempPhone, which sendPhoneOTP already normalised to
+      // E.164, so only ensure the '+' -- never inject a country code here.
+      const cleanPhone = rawPhone.replace(/\D/g, '');
+      const phone = `+${cleanPhone}`;
 
       let firebaseUid: string;
 
-      // Reviewer bypass — accept fixed OTP for the configured reviewer phone.
-      const reviewerPhone = process.env.EXPO_PUBLIC_REVIEWER_PHONE || '+919999999999';
-      const reviewerCode = process.env.EXPO_PUBLIC_REVIEWER_OTP ?? '123456';
-      
-      const cleanPhone = phone.replace(/\D/g, '');
-      const cleanReviewer = reviewerPhone.replace(/\D/g, '');
-      const isReviewer = cleanPhone.endsWith(cleanReviewer.slice(-10)) || phone === reviewerPhone;
+      // Reviewer bypass — full-number match, and only when explicitly
+      // configured. See sendPhoneOTP for why the previous last-10-digits
+      // comparison was unsafe across ~200 dialling codes.
+      const reviewerCode = process.env.EXPO_PUBLIC_REVIEWER_OTP?.trim();
+      const isReviewer = isReviewerPhone(phone);
 
-      if (isReviewer && code === reviewerCode) {
+      if (isReviewer && !!reviewerCode && code === reviewerCode) {
         firebaseUid = 'reviewer_bypass_' + cleanPhone.slice(-10);
       } else {
         if (__DEV__) console.log('[Auth] Verifying OTP via Firebase for', phone);


### PR DESCRIPTION
Addresses "175 country run app so otp all country not cheat" — which turned out to be **two** defects in the phone sign-in path.

## 1. Only four countries could sign in

`LoginScreen.tsx` held exactly four entries:

```js
const COUNTRIES: Country[] = [
  { name: 'United States', code: '+1',  flag: '🇺🇸' },
  { name: 'India',         code: '+91', flag: '🇮🇳' },
  { name: 'Canada',        code: '+1',  flag: '🇨🇦' },
  { name: 'United Kingdom',code: '+44', flag: '🇬🇧' },
];
```

The picker is the **only** way a dialling code reaches the store (`formattedPhone = \`${selectedCountry.code}${phoneNumber}\``). So users outside those four could not build a valid number and **could never receive an OTP**. For an app distributed in ~175 markets, sign-in was blocked almost everywhere.

Now `src/data/countries.ts` with the full E.164 table — **223 entries**. Flags are derived from the ISO 3166-1 alpha-2 code rather than hardcoded, so the table stays compact and a flag can't drift from its country.

Two latent bugs this exposed, also fixed:

- **Positional default.** `useState(COUNTRIES[1])` — with a reordered list that silently becomes a different country. Now looked up by ISO `'IN'`; India remains the default.
- **Ambiguous restore.** `COUNTRIES.find(c => c.code === countryCode)` — dialling codes aren't unique (`+1` spans the US, Canada and the Caribbean; `+44` spans the UK, Jersey, Guernsey, Isle of Man), so this resolved to whichever entry sorted first. Now keyed on ISO with the dialling code as fallback, and the ISO is persisted alongside it.

## 2. The OTP bypass accepted numbers it shouldn't

The reviewer check compared only the **last 10 digits**:

```js
cleanFormatted.endsWith(cleanReviewer.slice(-10))
```

With `+919999999999` that reduces to *"ends with 9999999999"* — so numbers in **any** dialling code skipped SMS verification. Widening the country list would have widened this too.

It also couldn't be switched off: `EXPO_PUBLIC_REVIEWER_PHONE` fell back to a hardcoded `'+919999999999'` and `EXPO_PUBLIC_REVIEWER_OTP` to `'123456'`, so the bypass stayed live in builds with **no configuration at all**.

Now matched on the **full E.164 number** through one shared `isReviewerPhone()` helper, requiring **both** env vars with no fallbacks.

| number | old | new |
|---|---|---|
| `+919999999999` (intended reviewer) | bypass | bypass |
| `+19999999999` | **bypass** | rejected |
| `+449999999999` | **bypass** | rejected |
| `+559999999999` | **bypass** | rejected |
| env vars unset | **bypass** | rejected |

## Also: removed the silent `+91` default

`sendPhoneOTP` did `phoneNumber.startsWith('+') ? ... : \`+91${cleaned}\``. A number arriving without `+` meant the country was lost upstream, and assuming India routed a non-Indian user's OTP to a wrong number. It now raises a clear error. `verifyPhoneOTP` only normalises the `+`, since its input already came from `sendPhoneOTP`.

## Left alone deliberately

The demo email/password bypass in `login()` is an **exact** match on `demo@marketingtool.pro` plus a configured password — not a wildcard — and those credentials are published in the review notes. Different risk profile, so out of scope here.

## ⚠️ Remaining limitation

This is still a **client-side** check, and `EXPO_PUBLIC_*` values are inlined into the JS bundle at build time — so marking them Secret in Expo doesn't keep them out of the shipped app. Configure the bypass only for the build handed to store review. The durable fix is moving the reviewer session into the Appwrite `phone-session` function so no bypass ships to users; that's recorded in the helper's doc comment. Happy to do it if you want.

## Test

- `tsc --noEmit` → clean
- country table → 223 entries, **0** duplicate names (so `keyExtractor={item => item.name}` stays valid), `findCountry('US')` → United States, default → India `+91` 🇮🇳
- bypass matrix above verified at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGMzbTTT7mLfTxCQkcn4Zf
