### PR TITLE
fix(android): supply the Play service account key at submit time

### DIFF
--- a/.github/workflows/android-deploy-selfcontained.yml
+++ b/.github/workflows/android-deploy-selfcontained.yml
@@ -107,6 +107,34 @@ jobs:
           set -euo pipefail
           eas build --platform android --profile production --non-interactive
 
+      # eas.json's serviceAccountKeyPath expects this file at the repo root. It is
+      # gitignored (*service-account*.json), so it only exists as a secret. The
+      # Expo-hosted copy of this key lives on the old, disabled account and was
+      # NOT carried over to aimarketintool-2-2-2-2, so without this step
+      # `eas submit --platform android` fails with no Play credentials.
+      - name: Restore Google Play service account key
+        if: >-
+          github.event_name == 'push' ||
+          github.event_name == 'release' ||
+          inputs.submit
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" > google-play-service-account.json
+          # The secret may be stored raw or base64-encoded; accept either.
+          if ! node -e 'JSON.parse(require("fs").readFileSync("google-play-service-account.json","utf8"))' 2>/dev/null; then
+            base64 -d < google-play-service-account.json > tmp.json 2>/dev/null && mv tmp.json google-play-service-account.json
+          fi
+          node -e '
+            const k = JSON.parse(require("fs").readFileSync("google-play-service-account.json","utf8"));
+            if (k.type !== "service_account" || !k.client_email) {
+              console.error("::error::GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is not a valid service account key");
+              process.exit(1);
+            }
+            console.log("Play service account restored:", k.client_email);
+          '
+
       - name: Submit to Google Play
         if: >-
           github.event_name == 'push' ||
@@ -114,4 +142,4 @@ jobs:
           inputs.submit
         run: |
           set -euo pipefail
-          eas submit --platform android --latest --non-interactive
+          eas submit --platform android --profile production --latest --non-interactive

--- a/eas.json
+++ b/eas.json
@@ -49,6 +49,9 @@
         "ascApiKeyId": "69JDXUCPU3",
         "ascApiKeyIssuerId": "313ffa8d-5aed-4aad-a012-b1057717634c",
         "ascAppId": "6758618412"
+      },
+      "android": {
+        "serviceAccountKeyPath": "./google-play-service-account.json"
       }
     }
   }


### PR DESCRIPTION
## The gap

After moving to the working Expo account, the Android half of auto-submit still could not run. The Google Play service-account key was only ever stored **Expo-side on the old, disabled account**, and it did not migrate:

| Account | Play submit key |
|---|---|
| `@aimarketintool-2-2-2/marketingtool` 🔴 disabled | **PRESENT** (`eas-submit@marketing-tool-484720…`) |
| `@aimarketintool-2-2-2-2/marketingtool` 🟢 live | **MISSING** |

So the Android build would succeed — and the upload keystore now matches Play — but `eas submit --platform android` would fail for want of credentials.

## The fix

Rather than re-uploading the key into Expo (which breaks again on the next account move), this uses the **same approach the iOS ASC key already uses**: keep it in a GitHub secret and write it to the path `eas.json` points at, just before submitting.

- **`eas.json`** — add `submit.production.android.serviceAccountKeyPath`.
- **`android-deploy-selfcontained.yml`** — restore the key from the existing `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` secret (accepts raw JSON *or* base64), validate it's a real `service_account` key, and fail loudly if not. Pass `--profile production` explicitly so the new config is actually used.

## Deliberately not changed

No `track` or `releaseStatus` in `eas.json`. EAS's defaults are what the previously-successful Android submissions used — pinning `production` here would silently start pushing straight to **all** users. That should be a conscious decision, not a side effect of this fix.

## Safety

- The key file is already covered by `.gitignore` (`*service-account*.json`), so it never lands in the repo.
- The workflow still contains **zero `uses:` lines**, so it keeps running under the org's restrictive Actions policy that blocks every other workflow.

## Verified

- `eas.json` parses; reports both `ios` and `android` submit config
- Workflow YAML parses — 9 steps, key restore correctly ordered **before** submit
- No `uses:` lines present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
